### PR TITLE
App store

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -88,7 +88,7 @@
         "title": "Emulated Comfort Cloud app version (override)",
         "description": "Leave this field empty to automatically fetch the latest version from the App Store and if that fails, it will use the last known working value which is hard-coded. Filling in this field will make the entered version used (automatic overwriting of versions from the App Store will not work).",
         "type": "string",
-        "placeholder": "1.17.0"
+        "placeholder": "App version, E.G.: 1.19.0"
       },
       "minHeatingTemperature": {
         "title": "Minimum heating temperature (override)",

--- a/config.schema.json
+++ b/config.schema.json
@@ -86,7 +86,7 @@
       },
       "appVersionOverride": {
         "title": "Emulated Comfort Cloud app version (override)",
-        "description": "The plugin will automatically fetch the latest version number from the App Store. If that fails, it will use the last known working value which is hard-coded. This setting allows you to override both of these if needed. It should normally reflect the latest version on the App Store.",
+        "description": "Leave this field empty to automatically fetch the latest version from the App Store and if that fails, it will use the last known working value which is hard-coded. Filling in this field will make the entered version used (automatic overwriting of versions from the App Store will not work).",
         "type": "string",
         "placeholder": "1.17.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Homebridge platform plugin providing HomeKit support for Panasonic air conditioners.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Homebridge platform plugin providing HomeKit support for Panasonic air conditioners.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -230,8 +230,7 @@ export default class ComfortCloudApi {
       'X-APP-TIMESTAMP': (new Date()).toISOString().replace(/-/g, '')
         .replace('T', ' ').slice(0, 17),
       'X-APP-TYPE': '0',
-      'X-APP-VERSION': this.config.appVersionOverride
-        || this.config.latestAppVersion || APP_VERSION,
+      'X-APP-VERSION': this.config.latestAppVersion || this.config.appVersionOverride || settings_1.APP_VERSION,
       'X-CFC-API-KEY': '0',
     };
   }

--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -231,7 +231,7 @@ export default class ComfortCloudApi {
         .replace('T', ' ').slice(0, 17),
       'X-APP-TYPE': '0',
       'X-APP-VERSION': this.config.appVersionOverride
-        || this.config.latestAppVersion || settings_1.APP_VERSION,
+        || this.config.latestAppVersion || APP_VERSION,
       'X-CFC-API-KEY': '0',
     };
   }

--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -230,7 +230,8 @@ export default class ComfortCloudApi {
       'X-APP-TIMESTAMP': (new Date()).toISOString().replace(/-/g, '')
         .replace('T', ' ').slice(0, 17),
       'X-APP-TYPE': '0',
-      'X-APP-VERSION': this.config.latestAppVersion || this.config.appVersionOverride || settings_1.APP_VERSION,
+      'X-APP-VERSION': this.config.latestAppVersion
+        || this.config.appVersionOverride || settings_1.APP_VERSION,
       'X-CFC-API-KEY': '0',
     };
   }

--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -230,8 +230,8 @@ export default class ComfortCloudApi {
       'X-APP-TIMESTAMP': (new Date()).toISOString().replace(/-/g, '')
         .replace('T', ' ').slice(0, 17),
       'X-APP-TYPE': '0',
-      'X-APP-VERSION': this.config.latestAppVersion
-        || this.config.appVersionOverride || settings_1.APP_VERSION,
+      'X-APP-VERSION': this.config.appVersionOverride
+        || this.config.latestAppVersion || settings_1.APP_VERSION,
       'X-CFC-API-KEY': '0',
     };
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,7 +20,7 @@ import {
   MAX_NO_OF_LOGIN_RETRIES,
   PLATFORM_NAME,
   PLUGIN_NAME,
-  APP_VERSION
+  APP_VERSION,
 } from './settings';
 
 
@@ -87,7 +87,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
   async getAppVersion() {
     this.log.info('Attempting to fetch latest Comfort Cloud version from the App Store.');
-    const curVersion = this.platformConfig.appVersionOverride || settings.APP_VERSION;
+    const curVersion = this.platformConfig.appVersionOverride || APP_VERSION;
     this.log.info(`Current App Version is: ${curVersion}.`);
     try {
       const response = await axios.request({

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -104,8 +104,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
           if (newVersion > curVersion) {
             this.platformConfig.latestAppVersion = newVersion;
             this.log.info(`New App Version available: ${newVersion}. Currently: ${curVersion}.`);
-          }
-          else {
+          } else {
             this.log.info(`No update available, You have latest App Version: ${curVersion}`);
           }
         } else {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -86,6 +86,8 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
   async getAppVersion() {
     this.log.info('Attempting to fetch latest Comfort Cloud version from the App Store.');
+    this.curVersion = this.platformConfig.appVersionOverride;
+    this.log.info(`Current App Version is: ${this.curVersion}.`);
     try {
       const response = await axios.request({
         method: 'get',
@@ -98,8 +100,14 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
         // followed by ., followed by one or more digit(s)
         const matches = $(p).text().match(/\d+(.)\d+(.)\d+/);
         if (Array.isArray(matches)) {
-          this.log.info(`The latest app version is ${matches[0]}.`);
-          this.platformConfig.latestAppVersion = matches[0];
+          this.newVersion = matches[0];
+          if (this.newVersion > this.curVersion) {
+            this.platformConfig.latestAppVersion = this.newVersion;				
+            this.log.info(`New App Version available: ${this.newVersion}. Currently: ${this.curVersion}.`);
+          }
+          else {
+            this.log.info(`No update available, You have latest App Version: ${this.curVersion}`);
+          }
         } else {
           this.log.error('Could not find latest app version. '
             + 'Falling back to override or hard-coded value.');

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -86,7 +86,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
   async getAppVersion() {
     this.log.info('Attempting to fetch latest Comfort Cloud version from the App Store.');
-    this.curVersion = this.platformConfig.appVersionOverride;
+    var curVersion = this.platformConfig.appVersionOverride;
     this.log.info(`Current App Version is: ${this.curVersion}.`);
     try {
       const response = await axios.request({
@@ -100,13 +100,13 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
         // followed by ., followed by one or more digit(s)
         const matches = $(p).text().match(/\d+(.)\d+(.)\d+/);
         if (Array.isArray(matches)) {
-          this.newVersion = matches[0];
-          if (this.newVersion > this.curVersion) {
-            this.platformConfig.latestAppVersion = this.newVersion;				
-            this.log.info(`New App Version available: ${this.newVersion}. Currently: ${this.curVersion}.`);
+          var newVersion = matches[0];
+          if (newVersion > curVersion) {
+            this.platformConfig.latestAppVersion = newVersion;				
+            this.log.info(`New App Version available: ${newVersion}. Currently: ${curVersion}.`);
           }
           else {
-            this.log.info(`No update available, You have latest App Version: ${this.curVersion}`);
+            this.log.info(`No update available, You have latest App Version: ${curVersion}`);
           }
         } else {
           this.log.error('Could not find latest app version. '

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -86,8 +86,8 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
   async getAppVersion() {
     this.log.info('Attempting to fetch latest Comfort Cloud version from the App Store.');
-    var curVersion = this.platformConfig.appVersionOverride;
-    this.log.info(`Current App Version is: ${this.curVersion}.`);
+    const curVersion = this.platformConfig.appVersionOverride;
+    this.log.info(`Current App Version is: ${curVersion}.`);
     try {
       const response = await axios.request({
         method: 'get',
@@ -100,9 +100,9 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
         // followed by ., followed by one or more digit(s)
         const matches = $(p).text().match(/\d+(.)\d+(.)\d+/);
         if (Array.isArray(matches)) {
-          var newVersion = matches[0];
+          const newVersion = matches[0];
           if (newVersion > curVersion) {
-            this.platformConfig.latestAppVersion = newVersion;				
+            this.platformConfig.latestAppVersion = newVersion;
             this.log.info(`New App Version available: ${newVersion}. Currently: ${curVersion}.`);
           }
           else {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,6 +20,7 @@ import {
   MAX_NO_OF_LOGIN_RETRIES,
   PLATFORM_NAME,
   PLUGIN_NAME,
+  APP_VERSION
 } from './settings';
 
 
@@ -86,7 +87,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
   async getAppVersion() {
     this.log.info('Attempting to fetch latest Comfort Cloud version from the App Store.');
-    const curVersion = this.platformConfig.appVersionOverride;
+    const curVersion = this.platformConfig.appVersionOverride || settings.APP_VERSION;
     this.log.info(`Current App Version is: ${curVersion}.`);
     try {
       const response = await axios.request({
@@ -101,12 +102,8 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
         const matches = $(p).text().match(/\d+(.)\d+(.)\d+/);
         if (Array.isArray(matches)) {
           const newVersion = matches[0];
-          if (newVersion > curVersion) {
-            this.platformConfig.latestAppVersion = newVersion;
-            this.log.info(`New App Version available: ${newVersion}. Currently: ${curVersion}.`);
-          } else {
-            this.log.info(`No update available, You have latest App Version: ${curVersion}`);
-          }
+          this.platformConfig.latestAppVersion = newVersion;
+          this.log.info(`App Store Version: ${newVersion}.`);
         } else {
           this.log.error('Could not find latest app version. '
             + 'Falling back to override or hard-coded value.');


### PR DESCRIPTION
In this order! this.config.latestAppVersion at the first place!

Why? Because this.config.latestAppVersion || this.config.appVersionOverride || settings_1.APP_VERSION; take first non empty value. In current code this.config.appVersionOverride is on first place and another values will not be ever used, even when there will be new version of app. So the function getAppVersion() don't have sence.

I also propose a small change in the function, so that the log shows the current version and the new one.