### PR TITLE
Promise reject fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Homebridge platform plugin providing HomeKit support for Panasonic air conditioners.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Homebridge platform plugin providing HomeKit support for Panasonic air conditioners.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -105,7 +105,7 @@ export default class ComfortCloudApi {
       .catch((error: AxiosError) => {
         this.log.debug('Comfort Cloud - getDevices(): Error');
         this.handleNetworkRequestError(error);
-        return Promise.reject();
+        return Promise.reject('Comfort Cloud - getDevices(): Error');
       });
   }
 
@@ -143,7 +143,7 @@ export default class ComfortCloudApi {
       .catch((error: AxiosError) => {
         this.log.debug(`Comfort Cloud - getDeviceStatus() for GUID '${deviceGuid}': Error`);
         this.handleNetworkRequestError(error);
-        return Promise.reject();
+        return Promise.reject(`Comfort Cloud - getDeviceStatus() for GUID '${deviceGuid}': Error`);
       });
   }
 
@@ -191,7 +191,7 @@ export default class ComfortCloudApi {
       .catch((error: AxiosError) => {
         this.log.debug('Comfort Cloud - setDeviceStatus(): Error');
         this.handleNetworkRequestError(error);
-        return Promise.reject();
+        return Promise.reject('Comfort Cloud - setDeviceStatus(): Error');
       });
   }
 


### PR DESCRIPTION
Why is it needed? Because otherwise homebridge sometimes restarts.