### PR TITLE
Include all subdirectories for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "dist/index.js",
   "scripts": {
     "clean": "rimraf ./dist",
-    "lint": "eslint src/**.ts --max-warnings=0",
+    "lint": "eslint src/ --ext .ts --max-warnings=0",
     "build": "npm run clean && tsc",
     "build-watch": "npm run clean && tsc -w",
     "prepublishOnly": "npm run lint && npm run build",


### PR DESCRIPTION
By looking at recent pull requests, I noticed that not all files were linted. This PR fixes this issue.