### PR TITLE
Refresh interval change

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The default heating temperature range is 16-30°C. Some Panasonic ACs have an ad
 Maximum number of failed login attempts. If set to 0 - without the limit.
 
 * `refreshInterval` (integer):
-Refresh interval in seconds.
+Refresh interval in minutes. Minimum 1 minute, maximum 360 minutes (6 hours). Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.
 
 * `oscilateSwitch` (string):
 Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.

--- a/config.schema.json
+++ b/config.schema.json
@@ -94,7 +94,7 @@
 				"required": true
 			},
 			"maxAttempts" : {
-				"title": "Maximum number of failed login attempts.",
+				"title": "Maximum number of failed login attempts",
 				"type": "integer",
 				"description": "0 - infinited. Minimum 0, Maximum 10.",
 				"required": true,
@@ -105,11 +105,11 @@
 			"refreshInterval" : {
 				"title": "Refresh interval (in seconds)",
 				"type": "integer",
-				"description": "Minimum 10, Maximum 300.",
+				"description": "Minimum 1 minute, Maximum 360 minutes (6 hours). Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.",
 				"required": true,
-				"default": 30,
-				"minimum": 10,
-				"maximum": 300
+				"default": 10,
+				"minimum": 1,
+				"maximum": 360
 			},
 			"swingModeDirections" : {
 				"title": "Swing Directions",

--- a/config.schema.json
+++ b/config.schema.json
@@ -103,9 +103,9 @@
 				"maximum": 10
 			},
 			"refreshInterval" : {
-				"title": "Refresh interval (in seconds)",
+				"title": "Refresh interval (in minutes)",
 				"type": "integer",
-				"description": "Minimum 1 minute, Maximum 360 minutes (6 hours). Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.",
+				"description": "Recomended: 10 minutes. Minimum 1 minute, Maximum 360 minutes (6 hours). Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.",
 				"required": true,
 				"default": 10,
 				"minimum": 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-panasonic-ac-platform",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-panasonic-ac-platform",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Homebridge platform plugin providing HomeKit support for Panasonic air conditioners.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -386,7 +386,7 @@ export default class IndoorUnitAccessory {
     if (!this._refreshInterval) {
       this._refreshInterval = setInterval(
         this.refreshDeviceStatus.bind(this),
-        this.platform.platformConfig.refreshInterval * 1000 || DEVICE_STATUS_REFRESH_INTERVAL,
+        this.platform.platformConfig.refreshInterval * 60 * 1000 || DEVICE_STATUS_REFRESH_INTERVAL,
       );
     }
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,5 +16,5 @@ export const MAX_NO_OF_LOGIN_RETRIES = 10;
 // 604,800 sec = 7 days
 export const LOGIN_TOKEN_REFRESH_INTERVAL = 604800 * 1000;
 
-// 10 sec
-export const DEVICE_STATUS_REFRESH_INTERVAL = 30 * 1000;
+// 10 minutes
+export const DEVICE_STATUS_REFRESH_INTERVAL = 10 * 60 * 1000;


### PR DESCRIPTION
CHANGELOG:
- Refresh interval change. Recomended: 10 minutes. Minimum 1 minute, Maximum 360 minutes (6 hours). Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.