### PR TITLE
Change refresh interval options. Remove max number of login attemps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,6 @@ The Home app offers no extra buttons for the Quiet and Powerful Modes. All setti
 - Panasonic has not provided an official API to support external plugins, so this method may stop working at any time.
 - Alternatives: 
     - Local access, but this requires reworking of the equipment, which will lose the warranty, so rather not recommended.
-    - Control by IR (imitates an IR remote control), E.G. through the Aqata Hub M2 or M3 gate, but it only allows you to send commands (not possible to read the state).
+    - Control by IR (imitates an IR remote control), E.G. through the Aqara Hub M2 or M3, but it only allows you to send commands (not possible to read the state).
 - Despite the efforts made, the operation of the plugin is without any guarantees and at your own risk.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -113,8 +113,8 @@
 				"default": 60,
 				"oneOf": [
 					{ "title": "Disabled", "enum": [0] },
-					{ "title": "10 min", "enum": [10] },
-					{ "title": "30 min", "enum": [30] },
+					{ "title": "10 minutes", "enum": [10] },
+					{ "title": "30 minutes", "enum": [30] },
 					{ "title": "1 hour", "enum": [60] },
 					{ "title": "6 hours", "enum": [360] },
 					{ "title": "12 hours", "enum": [720] },

--- a/config.schema.json
+++ b/config.schema.json
@@ -239,13 +239,13 @@
 			"expanded": false,
 			"items": [
 				"name",
-				"excludeDevices",
-				"debugMode",
-				"suppressOutgoingUpdates",
-				"appVersionOverride",
 				"refreshInterval",
+				"excludeDevices",
 				"exposeOutdoorUnit",
-				"minHeatingTemperature"
+				"minHeatingTemperature",
+				"appVersionOverride",
+				"suppressOutgoingUpdates",
+				"debugMode"
 			]
 		}
 	]

--- a/config.schema.json
+++ b/config.schema.json
@@ -29,7 +29,7 @@
 			"key2fa": {
 				"title": "2FA key",
 				"type": "string",
-				"description": "2FA key received from Panasonic. Example: GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H . Note: This field is not currently required to make this plugin work, but Panasonic already requires 2FA or SMS (recommended 2FA) to log in to Comfort Cloud, so it may be required soon.",
+				"description": "2FA key received from Panasonic (32 characters). Note: This field is currently not required to make this plugin work, but Panasonic already requires 2FA (code or SMS, recommended code) to log in to Comfort Cloud, so it may be required soon.",
 				"required": false
 			},
 			"excludeDevices": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -110,7 +110,7 @@
 				"type": "integer",
 				"description": "Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.",
 				"required": true,
-				"default": 30,
+				"default": 60,
 				"oneOf": [
 					{ "title": "Disabled", "enum": [0] },
 					{ "title": "10 min", "enum": [10] },

--- a/config.schema.json
+++ b/config.schema.json
@@ -115,8 +115,10 @@
 					{ "title": "Disabled", "enum": [0] },
 					{ "title": "10 min", "enum": [10] },
 					{ "title": "30 min", "enum": [30] },
-					{ "title": "60 min", "enum": [60] },
-					{ "title": "6 hours", "enum": [360] }
+					{ "title": "1 hour", "enum": [60] },
+					{ "title": "6 hours", "enum": [360] },
+					{ "title": "12 hours", "enum": [720] },
+					{ "title": "1 day", "enum": [1440] }
 				]
 			},
 			"swingModeDirections" : {

--- a/config.schema.json
+++ b/config.schema.json
@@ -106,13 +106,18 @@
 				"required": true
 			},
 			"refreshInterval" : {
-				"title": "Refresh interval (minutes)",
+				"title": "Refresh interval",
 				"type": "integer",
-				"description": "0 - disabled. Recomended min. 10 minutes. Maximum 360 minutes (6 hours). Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.",
+				"description": "Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.",
 				"required": true,
-				"default": 10,
-				"minimum": 0,
-				"maximum": 360
+				"default": 30,
+				"oneOf": [
+					{ "title": "Disabled", "enum": [0] },
+					{ "title": "10 min", "enum": [10] },
+					{ "title": "30 min", "enum": [30] },
+					{ "title": "60 min", "enum": [60] },
+					{ "title": "6 hours", "enum": [360] }
+				]
 			},
 			"swingModeDirections" : {
 				"title": "Swing Mode Directions",

--- a/config.schema.json
+++ b/config.schema.json
@@ -105,15 +105,6 @@
 				],
 				"required": true
 			},
-			"maxAttempts" : {
-				"title": "Maximum number of failed login attempts",
-				"type": "integer",
-				"description": "0 - infinited. Minimum 0, Maximum 10.",
-				"required": true,
-				"default": 0,
-				"minimum": 0,
-				"maximum": 10
-			},
 			"refreshInterval" : {
 				"title": "Refresh interval (minutes)",
 				"type": "integer",
@@ -245,7 +236,6 @@
 				"debugMode",
 				"suppressOutgoingUpdates",
 				"appVersionOverride",
-				"maxAttempts",
 				"refreshInterval",
 				"exposeOutdoorUnit",
 				"minHeatingTemperature"

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,7 +18,6 @@ Example:
         "appVersionOverride": "1.20.0",
         "suppressOutgoingUpdates": false,
         "minHeatingTemperature": 16,
-        "maxAttempts": 0,
         "refreshInterval": 10,
         "oscilateSwitch": "swing",
         "startSwing": false,
@@ -78,9 +77,6 @@ Eco Navi value with each state change made with Homekit (e.g. activation): do no
 
 * `startInsideCleaning` (string):
 InsideCleaning value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
-
-* `maxAttempts` (integer):
-Maximum number of failed login attempts. If set to 0 - without the limit.
 
 * `refreshInterval` (integer):
 Refresh interval in minutes. 0 - disabled. Recomended min. 10 minutes. Maximum 360 minutes (6 hours). Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,7 +46,7 @@ The password of your account.
 Optional:
 
 * `key2fa` (string): 
-2FA key received from Panasonic. Example: GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H . Note: This field is not currently required to make this plugin work, but Panasonic already requires 2FA or SMS (recommended 2FA) to log in to Comfort Cloud, so it may be required soon.
+2FA key received from Panasonic (32 characters). Example: GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H. Note: This field is currently not required to make this plugin work, but Panasonic already requires 2FA (code or SMS, recommended code) to log in to Comfort Cloud, so it may be required soon.
 
 * `oscilateSwitch` (string):
 Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,7 +18,7 @@ Example:
         "appVersionOverride": "1.20.0",
         "suppressOutgoingUpdates": false,
         "minHeatingTemperature": 16,
-        "refreshInterval": 10,
+        "refreshInterval": 60,
         "oscilateSwitch": "swing",
         "startSwing": false,
         "startNanoe": false,
@@ -79,7 +79,7 @@ Eco Navi value with each state change made with Homekit (e.g. activation): do no
 InsideCleaning value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
 
 * `refreshInterval` (integer):
-Refresh interval in minutes. 0 - disabled. Recomended min. 10 minutes. Maximum 360 minutes (6 hours). Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.
+Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.
 
 * `debugMode` (boolean):
 If `true`, the plugin will print debugging information to the Homebridge log.

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,18 +12,18 @@ Example:
         "email": "mail@example.com",
         "password": "********",
         "key2fa": "GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H",
-        "excludeDevices": "",
-        "exposeOutdoorUnit": true,
-        "debugMode": false,
-        "appVersionOverride": "1.20.0",
-        "suppressOutgoingUpdates": false,
-        "minHeatingTemperature": 16,
-        "refreshInterval": 60,
         "oscilateSwitch": "swing",
         "startSwing": false,
         "startNanoe": false,
         "startEcoNavi": false,
-        "startInsideCleaning": false
+        "startInsideCleaning": false,
+        "refreshInterval": 60,
+        "excludeDevices": "",
+        "exposeOutdoorUnit": true,
+        "minHeatingTemperature": 16,    
+        "appVersionOverride": "1.20.0",
+        "suppressOutgoingUpdates": false, 
+        "debugMode": false
     }
   ]
 }
@@ -48,21 +48,6 @@ Optional:
 * `key2fa` (string): 
 2FA key received from Panasonic. Example: GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H . Note: This field is not currently required to make this plugin work, but Panasonic already requires 2FA or SMS (recommended 2FA) to log in to Comfort Cloud, so it may be required soon.
 
-* `excludeDevices` (string): 
-By default this plugin will add all devices from Comfort Cloud. To exclude one or more, put comma separated names or serial numbers of devices, E.G.: 'CS-Z50VKEW+4962605183,Bedroom AC,CS-Z50VKEW+4962605184,My AC unit'. 
-
-* `exposeOutdoorUnit` (boolean):
-If `true`, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.
-
-* `suppressOutgoingUpdates` (boolean):
-If `true`, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.
-
-* `appVersionOverride` (string):
-The plugin will automatically use the last known working value when this setting is empty or undefined (default). This setting allows you to override the default value if needed. It should reflect the latest version on the App Store, although older clients might remain supported for some time.
-
-* `minHeatingTemperature` (integer):
-The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.
-
 * `oscilateSwitch` (string):
 Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.
 
@@ -80,6 +65,21 @@ InsideCleaning value with each state change made with Homekit (e.g. activation):
 
 * `refreshInterval` (integer):
 Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.
+
+* `excludeDevices` (string): 
+By default this plugin will add all devices from Comfort Cloud. To exclude one or more, put comma separated names or serial numbers of devices, E.G.: 'CS-Z50VKEW+4962605183,Bedroom AC,CS-Z50VKEW+4962605184,My AC unit'. 
+
+* `exposeOutdoorUnit` (boolean):
+If `true`, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.
+
+* `minHeatingTemperature` (integer):
+The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.
+
+* `suppressOutgoingUpdates` (boolean):
+If `true`, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.
+
+* `appVersionOverride` (string):
+The plugin will automatically use the last known working value when this setting is empty or undefined (default). This setting allows you to override the default value if needed. It should reflect the latest version on the App Store, although older clients might remain supported for some time.
 
 * `debugMode` (boolean):
 If `true`, the plugin will print debugging information to the Homebridge log.

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -384,7 +384,7 @@ export default class IndoorUnitAccessory {
     }
 
     // Schedule continuous device updates on the first run
-    if (!this._refreshInterval && this.platform.platformConfig.refreshInterval > 10) {
+    if (!this._refreshInterval && this.platform.platformConfig.refreshInterval >= 10) {
       this._refreshInterval = setInterval(
         this.refreshDeviceStatus.bind(this),
         this.platform.platformConfig.refreshInterval * 60 * 1000 || 360000);

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -1,7 +1,6 @@
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import PanasonicPlatform from '../platform';
 import OutdoorUnitAccessory from './outdoor-unit';
-import { DEVICE_STATUS_REFRESH_INTERVAL } from '../settings';
 import { ComfortCloudDeviceUpdatePayload, PanasonicAccessoryContext } from '../types';
 import {
   ComfortCloudAirSwingLR,

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -385,11 +385,10 @@ export default class IndoorUnitAccessory {
     }
 
     // Schedule continuous device updates on the first run
-    if (!this._refreshInterval && this.platform.platformConfig.refreshInterval > 0) {
+    if (!this._refreshInterval && this.platform.platformConfig.refreshInterval > 10) {
       this._refreshInterval = setInterval(
         this.refreshDeviceStatus.bind(this),
-        this.platform.platformConfig.refreshInterval * 60 * 1000 || DEVICE_STATUS_REFRESH_INTERVAL,
-      );
+        this.platform.platformConfig.refreshInterval * 60 * 1000 || 360000);
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -179,7 +179,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
           const delayMap = new Map([
             [1, 300], // 5 min
             [2, 1800], // 30 min
-            [3, 3600] // 60 min
+            [3, 3600], // 60 min
           ]);
           const nextRetryDelay = delayMap.get(this.noOfFailedLoginAttempts) || 28800;
 
@@ -190,7 +190,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
             nextRetryDelay * 1000,
           );
         }
-        
+
       });
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,10 +7,6 @@ export const PLATFORM_NAME = 'Panasonic AC Platform';
 export const COMFORT_CLOUD_USER_AGENT = 'G-RAC';
 export const APP_VERSION = '1.20.0';
 
-// 360 sec = 6 min
-export const LOGIN_RETRY_BASE_DELAY = 360;
-export const MAX_NO_OF_LOGIN_RETRIES = 10;
-
 // Used to renew the token periodically. Only a safety measure, since we are handling
 // network errors dynamically and re-issuing a login upon a 401 Unauthorized error.
 // 604,800 sec = 7 days

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,3 @@ export const APP_VERSION = '1.20.0';
 // network errors dynamically and re-issuing a login upon a 401 Unauthorized error.
 // 604,800 sec = 7 days
 export const LOGIN_TOKEN_REFRESH_INTERVAL = 604800 * 1000;
-
-// 10 minutes
-export const DEVICE_STATUS_REFRESH_INTERVAL = 10 * 60 * 1000;


### PR DESCRIPTION
Release notes (changelog):
- change refresh interval options to: disabled, 10 minutes, 30 minutes, 1 hour, 6 hours, 12 hours, 1 day - after the update, check the config and select the appropriate option.
- remove 'maximum number of login attempts'.
- simplification of intervals between login attempts.
- prepare to support 2FA.
- dependency upgrades.