### PR TITLE
Support for Fan and Dry mode

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -196,9 +196,9 @@
 				"type": "string",
 				"default": "auto",
 				"oneOf": [
-					{ "title": "Only errors and important info", "enum": ["auto"] },
-					{ "title": "Standard", "enum": ["fan"] },
-					{ "title": "All (including debug)", "enum": ["dry"] }
+					{ "title": "Auto mode", "enum": ["auto"] },
+					{ "title": "Fan mode", "enum": ["fan"] },
+					{ "title": "Dry mode", "enum": ["dry"] }
 				],
 				"required": true
 			}

--- a/config.schema.json
+++ b/config.schema.json
@@ -189,6 +189,18 @@
 					{ "title": "All (including debug)", "enum": [2] }
 				],
 				"required": true
+			},
+			"autoMode" : {
+				"title": "Auto Mode",
+				"description": "Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
+				"type": "string",
+				"default": "auto",
+				"oneOf": [
+					{ "title": "Only errors and important info", "enum": ["auto"] },
+					{ "title": "Standard", "enum": ["fan"] },
+					{ "title": "All (including debug)", "enum": ["dry"] }
+				],
+				"required": true
 			}
 		}
 	},
@@ -228,6 +240,7 @@
 			"expanded": false,
 			"description": "HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions.",
 			"items": [
+				"autoMode",
 				"oscilateSwitch",
 				"startSwing",
 				"startNanoe",

--- a/config.schema.json
+++ b/config.schema.json
@@ -235,7 +235,7 @@
 		},
 		{
 			"type": "fieldset",
-			"title": "More control (Swing, Nanoe, Eco Navi, Inside Cleaning)",
+			"title": "More control: Fan, Dry, Swing, Nanoe, Eco Navi, Inside Cleaning",
 			"expandable": true,
 			"expanded": false,
 			"description": "HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions.",

--- a/config.schema.json
+++ b/config.schema.json
@@ -238,7 +238,7 @@
 			"title": "More control: Fan, Dry, Swing, Nanoe, Eco Navi, Inside Cleaning",
 			"expandable": true,
 			"expanded": false,
-			"description": "HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions.",
+			"description": "HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions.",
 			"items": [
 				"autoMode",
 				"oscilateSwitch",

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,7 @@ Example:
         "email": "mail@example.com",
         "password": "********",
         "key2fa": "GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H",
+        "autoMode": "auto",
         "oscilateSwitch": "swing",
         "startSwing": false,
         "startNanoe": false,
@@ -47,6 +48,9 @@ Optional:
 
 * `key2fa` (string): 
 2FA key received from Panasonic (32 characters). Example: GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H. Note: This field is currently not required to make this plugin work, but Panasonic already requires 2FA (code or SMS, recommended code) to log in to Comfort Cloud, so it may be required soon.
+
+* `autoMode` (string):
+Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).
 
 * `oscilateSwitch` (string):
 Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -512,8 +512,16 @@ export default class IndoorUnitAccessory {
     };
     switch (value) {
       case this.platform.Characteristic.TargetHeaterCoolerState.AUTO:
-        parameters.operationMode = 0;
-        this.platform.log.debug(`${this.accessory.displayName}: Mode Auto`);
+        if (this.platform.platformConfig.autoMode === 'fan') {
+          parameters.operationMode = 4;
+          this.platform.log.debug(`${this.accessory.displayName}: Fan Mode`);
+        } else if (this.platform.platformConfig.autoMode === 'dry') {
+          parameters.operationMode = 1;
+          this.platform.log.debug(`${this.accessory.displayName}: Dry mode`);
+        } else {
+          parameters.operationMode = 0;
+          this.platform.log.debug(`${this.accessory.displayName}: Auto mode`);
+        }
         break;
 
       case this.platform.Characteristic.TargetHeaterCoolerState.COOL:


### PR DESCRIPTION
Changelog:
- in the plugin settings, you can choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).
- dependencies upgrades.