### PR TITLE
Version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Example:
         "devices": [
                 {
                     "name": "CS-Z50VKEW+4942673181",
-                    "exclude" false,
                     "exposeOutdoorUnit": false,
                     "forceSwing": "false",
                     "forceNanoe": "false",
@@ -85,7 +84,6 @@ Example:
                 },
                 {
                     "name": "Bedroom AC",
-                    "exclude" false,
                     "exposeOutdoorUnit": false,
                     "forceSwing": "false",
                     "forceNanoe": "false",
@@ -123,9 +121,6 @@ When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful 
 Logs level. 0 - only errors and important info, 1 - standard,2 - all (including debug).
 
 ## Inividual for each device
-
-* `exclude` (boolean):
-Exclude this device from Homebridge and HomeKit. This will not remove device from Comfort Cloud.
 
 * `autoMode` (string):
 HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Logs level. 0 - only errors and important info, 1 - standard,2 - all (including 
 Exclude this device from Homebridge and HomeKit. This will not remove device from Comfort Cloud.
 
 * `autoMode` (string):
-Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).
+HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).
 
 * `oscilateSwitch` (string):
 HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions. Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.
@@ -145,6 +145,15 @@ Eco Navi value with each state change made with Homekit (e.g. activation): do no
 * `forceInsideCleaning` (string):
 InsideCleaning value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
 
+* `swingModeDirections`
+Desired swing direction(s) activated when swing is switched on.
+
+* `swingModeDefaultPositionUpDown`
+Desired position of the Up-Down flaps when swing is switched off or the swing directions setting is Left-Right only.
+
+* `swingModeDefaultPositionLeftRight`
+Desired position of the Left-Right flaps when swing is switched off or the swing directions setting is Up-Down only.
+
 * `exposeOutdoorUnit` (boolean):
 When enabled, the plugin will create a dummy temperature accessory which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.
 
@@ -154,9 +163,7 @@ The default heating temperature range is 16-30°C. Some Panasonic ACs have an ad
 
 </details>
 
-## Mode (Heat, Cool etc.)
 
-HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default). Everytime When a mode other than Heat or Cool is selected in the Panasonic application or using the remote control, the Auto mode will be enabled in HomeKit.
 
 ## Rotation speed (including Quiet Mode, Powerful Mode)
 
@@ -174,23 +181,9 @@ The Home app offers no extra buttons for the Quiet and Powerful Modes. All setti
 | 7                         | Powerful mode         |
 | (rightmost) 8             | Auto                  |
 
-## Oscillate Switch
 
-HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions. Decide what the switch should control.
 
-## Swing modes
 
-Homekit doesn't have so many switches to support all Swing modes. That's why here you can choose how it works.
-
-* The setting `Swing Directions` (`swingModeDirections` in the JSON config) controls which swing direction(s) will be activated when 'Oscillate' is switched on.
-
-* The setting `Swing Mode Default Position (Left-Right)` (`swingModeDefaultPositionLeftRight` in the JSON config) controls the desired position of the Left-Right flaps when 'Oscillate' is switched off or the swing directions setting (see above) is "Up-Down only".
-
-* The setting `Swing Mode Default Position (Up-Down)` (`swingModeDefaultPositionUpDown` in the JSON config) controls the desired position of the Up-Down flaps when 'Oscillate' is switched off or the swing directions setting (see above) is "Left-Right only".
-
-## Override values
-
-Values with each state change made with Homekit (e.g. activation). For Swing Mode, Nanoe, Eco Navi and Inside Cleaning. Available options: do nothing, set on, set off.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Desired position of the Up-Down flaps when swing is switched off or the swing di
 Desired position of the Left-Right flaps when swing is switched off or the swing directions setting is Up-Down only.
 
 * `exposeOutdoorUnit` (boolean):
-When enabled, the plugin will create a dummy temperature accessory which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.
+When enabled it will create a dummy temperature sensor which will display the temperature from outdoor unit. This can be used for monitoring or automation purposes.
 
 * `minHeatingTemperature` (integer):
 The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. You can use this setting to adjust the minimum value. Leave it empty to use the default value.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Example:
         "devices": [
                 {
                     "name": "CS-Z50VKEW+4942673181",
+                    "excludeDevice": true,
                     "exposeOutdoorUnit": false,
                     "forceSwing": "false",
                     "forceNanoe": "false",
@@ -84,6 +85,7 @@ Example:
                 },
                 {
                     "name": "Bedroom AC",
+                    "excludeDevice": false,
                     "exposeOutdoorUnit": false,
                     "forceSwing": "false",
                     "forceNanoe": "false",
@@ -121,6 +123,9 @@ When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful 
 Logs level. 0 - only errors and important info, 1 - standard,2 - all (including debug).
 
 ## Inividual for each device
+
+* `excludeDevice` (boolean):
+Exclude device from Homebridge and HomeKit (it will stay in Comfort Cloud).
 
 * `autoMode` (string):
 HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This plugin can be easily installed and configured through Homebridge UI or via 
 
     npm install -g homebridge-panasonic-ac-platform
 
-## Homebridge setup
+## Configure plugin
 Configure the plugin through the settings UI or directly in the JSON editor.
 
 Basic settings (required):
@@ -45,12 +45,12 @@ Basic settings (required):
 ```
 
 - `platform` (string): Tells Homebridge which platform this config belongs to. Leave as is.
-- `name` (string): Will be displayed in the Homebridge log.
+- `name` (string): Name of the plugin in Homebridge log.
 - `email` (string): The username of your Comfort Cloud (Panasonic ID) account.
 - `password` (string): The password of your Comfort Cloud (Panasonic ID) account.
 
 <details>
-<summary><b>Advanced configuration</b></summary>
+<summary><b>Advanced configuration and individual device settings</b></summary>
 
 Example:
 
@@ -63,65 +63,94 @@ Example:
         "email": "mail@example.com",
         "password": "********",
         "key2fa": "GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H",
-        "autoMode": "auto",
-        "oscilateSwitch": "swing",
-        "startSwing": false,
-        "startNanoe": false,
-        "startEcoNavi": false,
-        "startInsideCleaning": false,
         "refreshInterval": 60,
         "excludeDevices": "",
-        "exposeOutdoorUnit": true,
-        "minHeatingTemperature": 16,    
-        "appVersionOverride": "1.20.0",
+        "appVersionOverride": "1.21.0",
         "suppressOutgoingUpdates": false, 
-        "logsLevel": 0
+        "logsLevel": 1,
+        "devices": [
+                {
+                    "name": "CS-Z50VKEW+4942673181",
+                    "exclude" false,
+                    "exposeOutdoorUnit": false,
+                    "forceSwing": "false",
+                    "forceNanoe": "false",
+                    "forceEcoNavi": "false",
+                    "forceInsideCleaning": "false",
+                    "oscilateSwitch": "swing",
+                    "swingModeDirections": "LEFT-RIGHT-UP-DOWN",
+                    "swingModeDefaultPositionLeftRight": "CENTER",
+                    "swingModeDefaultPositionUpDown": "CENTER",
+                    "autoMode": "auto"
+                },
+                {
+                    "name": "Bedroom AC",
+                    "exclude" false,
+                    "exposeOutdoorUnit": false,
+                    "forceSwing": "false",
+                    "forceNanoe": "false",
+                    "forceEcoNavi": "false",
+                    "forceInsideCleaning": "false",
+                    "oscilateSwitch": "swing",
+                    "swingModeDirections": "LEFT-RIGHT-UP-DOWN",
+                    "swingModeDefaultPositionLeftRight": "CENTER",
+                    "swingModeDefaultPositionUpDown": "CENTER",
+                    "autoMode": "auto"
+                }
+            ]
     }
   ]
 }
 ```
+## Advanced fields
 
 * `key2fa` (string): 
 2FA key received from Panasonic (32 characters). Example: GVZCKT2LLBLV2QBXMFAWFXKFKU5EWL2H. Note: This field is currently not required to make this plugin work, but Panasonic already requires 2FA (code or SMS, recommended code) to log in to Comfort Cloud, so it may be required soon.
-
-* `autoMode` (string):
-Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).
-
-* `oscilateSwitch` (string):
-Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.
-
-* `startSwing` (string):
-Swing value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
-
-* `startNanoe` (string):
-Nanoe value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
-
-* `startEcoNavi` (string):
-Eco Navi value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
-
-* `startInsideCleaning` (string):
-InsideCleaning value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
 
 * `refreshInterval` (integer):
 Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.
 
 * `excludeDevices` (string): 
-By default this plugin will add all devices from Comfort Cloud. To exclude one or more, put comma separated names or serial numbers of devices, E.G.: 'CS-Z50VKEW+4962605183,Bedroom AC,CS-Z50VKEW+4962605184,My AC unit'. 
-
-* `exposeOutdoorUnit` (boolean):
-If `true`, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.
-
-* `minHeatingTemperature` (integer):
-The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.
-
-* `suppressOutgoingUpdates` (boolean):
-If `true`, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.
+By default this plugin will add all devices from Comfort Cloud. To exclude one or more, put comma separated names or serial numbers of devices, E.G.: 'CS-Z50VKEW+4962605183,Bedroom AC,CS-Z50VKEW+4962605184,My AC unit'.
 
 * `appVersionOverride` (string):
-The plugin will automatically use the last known working value when this setting is empty or undefined (default). This setting allows you to override the default value if needed. It should reflect the latest version on the App Store, although older clients might remain supported for some time.
+Leave this field empty to automatically fetch the latest version from the App Store and if that fails, it will use the last known working value which is hard-coded. Filling in this field will make the entered version used (automatic overwriting of versions from the App Store will not work).
+
+* `suppressOutgoingUpdates` (boolean):
+When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC.
 
 * `logsLevel` (integer):
 Logs level. 0 - only errors and important info, 1 - standard,2 - all (including debug).
+
+## Inividual for each device
+
+* `exclude` (boolean):
+Exclude this device from Homebridge and HomeKit. This will not remove device from Comfort Cloud.
+
+* `autoMode` (string):
+Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).
+
+* `oscilateSwitch` (string):
+HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions. Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.
+
+* `forceSwing` (string):
+Swing value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
+
+* `forceNanoe` (string):
+Nanoe value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
+
+* `forceEcoNavi` (string):
+Eco Navi value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
+
+* `forceInsideCleaning` (string):
+InsideCleaning value with each state change made with Homekit (e.g. activation): do nothing, set on, set off.
+
+* `exposeOutdoorUnit` (boolean):
+When enabled, the plugin will create a dummy temperature accessory which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.
+
+* `minHeatingTemperature` (integer):
+The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. You can use this setting to adjust the minimum value. Leave it empty to use the default value.
+
 
 </details>
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -420,7 +420,7 @@
 						},
 						"exposeOutdoorUnit": {
 							"title": "Expose Outdoor Unit",
-							"description": "When enabled, the plugin will create a dummy temperature accessory which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
+							"description": "When enabled it will create a dummy temperature sensor which will display the temperature from outdoor unit. This can be used for monitoring or automation purposes.",
 							"type": "boolean",
 							"default": false
 						},

--- a/config.schema.json
+++ b/config.schema.json
@@ -4,15 +4,7 @@
 	"singular": true,
 	"schema": {
 		"type": "object",
-		"properties": {
-			"name": {
-				"title": "Plugin Name",
-				"description": "This name will be displayed in the Homebridge log.",
-				"type": "string",
-				"default": "Homebridge Panasonic AC Platform",
-				"placeholder": "Homebridge Panasonic AC Platform",
-				"required": true
-			},
+		"properties": {		
 			"email": {
 				"title": "Email",
 				"type": "string",
@@ -32,157 +24,12 @@
 				"description": "2FA key received from Panasonic (32 characters). Note: This field is currently not required to make this plugin work, but Panasonic already requires 2FA (code or SMS, recommended code) to log in to Comfort Cloud, so it may be required soon.",
 				"required": false
 			},
-			"excludeDevices": {
-				"title": "Exclude Devices",
+			"name": {
+				"title": "Plugin Name",
+				"description": "This name will be displayed in the Homebridge log.",
 				"type": "string",
-				"description": "By default this plugin will add all devices from Comfort Cloud. To exclude one or more, put comma separated names or serial numbers of devices, E.G.: 'CS-Z50VKEW+4962605183,Bedroom AC,CS-Z50VKEW+4962605184,My AC unit'.",
-				"required": false
-			},
-			"exposeOutdoorUnit": {
-				"title": "Expose Outdoor Unit",
-				"description": "When enabled, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
-				"type": "boolean",
-				"default": false
-			},
-			"startSwing": {
-				"title": "Override Swing",
-				"description": "Swing value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-				"type": "string",
-				"default": "false",
-				"required": true,
-				"oneOf": [
-					{
-						"title": "Do nothing",
-						"enum": [
-							"false"
-						]
-					},
-					{
-						"title": "Set on",
-						"enum": [
-							"on"
-						]
-					},
-					{
-						"title": "Set off",
-						"enum": [
-							"off"
-						]
-					}
-				]
-			},
-			"startNanoe": {
-				"title": "Override Nanoe",
-				"description": "Nanoe value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-				"type": "string",
-				"default": "false",
-				"oneOf": [
-					{
-						"title": "Do nothing",
-						"enum": [
-							"false"
-						]
-					},
-					{
-						"title": "Set on",
-						"enum": [
-							"on"
-						]
-					},
-					{
-						"title": "Set off",
-						"enum": [
-							"off"
-						]
-					}
-				],
-				"required": true
-			},
-			"startEcoNavi": {
-				"title": "Override Eco Navi",
-				"description": "Eco Navi value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-				"type": "string",
-				"default": "false",
-				"oneOf": [
-					{
-						"title": "Do nothing",
-						"enum": [
-							"false"
-						]
-					},
-					{
-						"title": "Set on",
-						"enum": [
-							"on"
-						]
-					},
-					{
-						"title": "Set off",
-						"enum": [
-							"off"
-						]
-					}
-				],
-				"required": true
-			},
-			"startInsideCleaning": {
-				"title": "Override Inside Cleaning",
-				"description": "Inside Cleaning value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-				"type": "string",
-				"default": "false",
-				"oneOf": [
-					{
-						"title": "Do nothing",
-						"enum": [
-							"false"
-						]
-					},
-					{
-						"title": "Set on",
-						"enum": [
-							"on"
-						]
-					},
-					{
-						"title": "Set off",
-						"enum": [
-							"off"
-						]
-					}
-				],
-				"required": true
-			},
-			"oscilateSwitch": {
-				"title": "Oscilate Switch",
-				"description": "Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.",
-				"type": "string",
-				"default": "swing",
-				"oneOf": [
-					{
-						"title": "Swing Mode",
-						"enum": [
-							"swing"
-						]
-					},
-					{
-						"title": "Nanoe",
-						"enum": [
-							"nanoe"
-						]
-					},
-					{
-						"title": "Eco Navi",
-						"enum": [
-							"ecoNavi"
-						]
-					},
-					{
-						"title": "Inside Cleaning",
-						"enum": [
-							"insideCleaning"
-						]
-					}
-				],
+				"default": "Homebridge Panasonic AC Platform",
+				"placeholder": "Homebridge Panasonic AC Platform",
 				"required": true
 			},
 			"refreshInterval": {
@@ -236,115 +83,11 @@
 					}
 				]
 			},
-			"swingModeDirections": {
-				"title": "Swing Mode Directions",
-				"description": "Swing direction(s) when activated via HomeKit (by 'Oscillate switch' or by 'Override Swing').",
+			"excludeDevices": {
+				"title": "Exclude Devices",
 				"type": "string",
-				"default": "LEFT-RIGHT-UP-DOWN",
-				"oneOf": [
-					{
-						"title": "Left-Right and Up-Down",
-						"enum": [
-							"LEFT-RIGHT-UP-DOWN"
-						]
-					},
-					{
-						"title": "Left-Right only",
-						"enum": [
-							"LEFT-RIGHT"
-						]
-					},
-					{
-						"title": "Up-Down only",
-						"enum": [
-							"UP-DOWN"
-						]
-					}
-				],
-				"required": true
-			},
-			"swingModeDefaultPositionLeftRight": {
-				"title": "Swing Mode Default Position (Left-Right)",
-				"description": "Position of the Left-Right flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
-				"type": "string",
-				"default": "CENTER",
-				"oneOf": [
-					{
-						"title": "Left",
-						"enum": [
-							"LEFT"
-						]
-					},
-					{
-						"title": "Center-Left",
-						"enum": [
-							"CENTER-LEFT"
-						]
-					},
-					{
-						"title": "Center",
-						"enum": [
-							"CENTER"
-						]
-					},
-					{
-						"title": "Center-Right",
-						"enum": [
-							"CENTER-RIGHT"
-						]
-					},
-					{
-						"title": "Right",
-						"enum": [
-							"RIGHT"
-						]
-					}
-				],
-				"required": true
-			},
-			"swingModeDefaultPositionUpDown": {
-				"title": "Swing Mode Default Position (Up-Down)",
-				"description": "Position of the Up-Down flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
-				"type": "string",
-				"default": "CENTER",
-				"oneOf": [
-					{
-						"title": "Up",
-						"enum": [
-							"UP"
-						]
-					},
-					{
-						"title": "Center-Up",
-						"enum": [
-							"CENTER-UP"
-						]
-					},
-					{
-						"title": "Center",
-						"enum": [
-							"CENTER"
-						]
-					},
-					{
-						"title": "Center-Down",
-						"enum": [
-							"CENTER-DOWN"
-						]
-					},
-					{
-						"title": "Down",
-						"enum": [
-							"DOWN"
-						]
-					}
-				],
-				"required": true
-			},
-			"suppressOutgoingUpdates": {
-				"title": "Suppress outgoing device updates",
-				"description": "When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.",
-				"type": "boolean"
+				"description": "By default this plugin will add all devices from Comfort Cloud. To exclude one or more, put comma separated names or serial numbers of devices, E.G.: 'CS-Z50VKEW+4962605183,Bedroom AC,CS-Z50VKEW+4962605184,My AC unit'.",
+				"required": false
 			},
 			"appVersionOverride": {
 				"title": "Comfort Cloud app version (override)",
@@ -352,11 +95,10 @@
 				"type": "string",
 				"placeholder": "App version, E.G.: 1.19.0"
 			},
-			"minHeatingTemperature": {
-				"title": "Minimum heating temperature (override)",
-				"description": "The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
-				"type": "integer",
-				"placeholder": "16"
+			"suppressOutgoingUpdates": {
+				"title": "Suppress outgoing devices updates",
+				"description": "When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC.",
+				"type": "boolean"
 			},
 			"logsLevel": {
 				"title": "Logs Level",
@@ -385,54 +127,25 @@
 				],
 				"required": true
 			},
-			"autoMode": {
-				"title": "Auto Mode",
-				"description": "Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
-				"type": "string",
-				"default": "auto",
-				"oneOf": [
-					{
-						"title": "Auto mode",
-						"enum": [
-							"auto"
-						]
-					},
-					{
-						"title": "Fan mode",
-						"enum": [
-							"fan"
-						]
-					},
-					{
-						"title": "Dry mode",
-						"enum": [
-							"dry"
-						]
-					}
-				],
-				"required": true
-			},
 			"devices": {
 				"type": "array",
 				"items": {
 					"type": "object",
 					"properties": {
 						"name": {
+							"title": "Name or serial number",
 							"type": "string",
 							"required": true,
-							"description": "Device name or serial (E.G.: CS-Z50VKEW+2462503161)."
+							"description": "Device name (as it is in Comfort Cloud account) or serial (E.G.: CS-Z50VKEW+2462503161)."
 						},
-						"mess": {
-							"type": "string",
-							"required": false
-						},
-						"disabled": {
+						"exclude": {
+							"title": "Exclude device",
 							"type": "boolean",
-							"description": "Exclude this device."
+							"description": "Exclude this device from Homebridge and HomeKit. This will not remove device from Comfort Cloud."
 						},
 						"exposeOutdoorUnit": {
 							"title": "Expose Outdoor Unit",
-							"description": "When enabled, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
+							"description": "When enabled, the plugin will create a dummy temperature accessory which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
 							"type": "boolean",
 							"default": false
 						},
@@ -546,7 +259,7 @@
 						},
 						"oscilateSwitch": {
 							"title": "Oscilate Switch",
-							"description": "Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.",
+							"description": "HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions. Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.",
 							"type": "string",
 							"default": "swing",
 							"oneOf": [
@@ -682,20 +395,15 @@
 							],
 							"required": true
 						},
-						"suppressOutgoingUpdates": {
-							"title": "Suppress outgoing device updates",
-							"description": "When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.",
-							"type": "boolean"
-						},
 						"minHeatingTemperature": {
 							"title": "Minimum heating temperature (override)",
-							"description": "The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
+							"description": "The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. You can use this setting to adjust the minimum value. Leave it empty to use the default value.",
 							"type": "integer",
 							"placeholder": "16"
 						},
 						"autoMode": {
 							"title": "Auto Mode",
-							"description": "Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
+							"description": "HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
 							"type": "string",
 							"default": "auto",
 							"oneOf": [
@@ -728,63 +436,26 @@
 	"layout": [
 		{
 			"type": "fieldset",
-			"title": "Basic settings",
-			"description": "Enter your Panasonic Comfort Cloud login details. It is recommended to set up a separate account for Homebridge and share the devices from your main account.",
+			"title": "Account",
+			"description": "Enter your Panasonic Comfort Cloud login details.",
 			"expandable": true,
 			"expanded": true,
 			"items": [
-				{
-					"type": "flex",
-					"flex-flow": "row wrap",
-					"items": [
-						{
-							"key": "email",
-							"type": "email"
-						},
-						{
-							"key": "password",
-							"type": "password"
-						}
-					]
-				},
-				{
-					"type": "flex",
-					"flex-flow": "row wrap",
-					"items": [
-						"key2fa"
-					]
-				}
+				"email",
+				"password",
+				"key2fa"
 			]
 		},
+		
 		{
 			"type": "fieldset",
-			"title": "More control: Fan, Dry, Swing, Nanoe, Eco Navi, Inside Cleaning",
-			"expandable": true,
-			"expanded": false,
-			"description": "HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. HomeKit has only one 'Oscillate' switch, but most Panasonic ACs have more options: Nanoe, Eco Navi, Inside Cleaning and Swing mode have two swing directions.",
-			"items": [
-				"autoMode",
-				"oscilateSwitch",
-				"startSwing",
-				"startNanoe",
-				"startEcoNavi",
-				"startInsideCleaning",
-				"swingModeDirections",
-				"swingModeDefaultPositionLeftRight",
-				"swingModeDefaultPositionUpDown"
-			]
-		},
-		{
-			"type": "fieldset",
-			"title": "Advanced settings",
+			"title": "Advanced",
 			"expandable": true,
 			"expanded": false,
 			"items": [
 				"name",
 				"refreshInterval",
 				"excludeDevices",
-				"exposeOutdoorUnit",
-				"minHeatingTemperature",
 				"appVersionOverride",
 				"suppressOutgoingUpdates",
 				"logsLevel"
@@ -800,91 +471,46 @@
 			"expanded": false,
 			"items": [
 				{
-					"type": "div",
-					"displayFlex": true,
-					"flex-flow": "row wrap",
+					"type": "fieldset",
 					"items": [
-						{
-							"key": "devices[].name",
-							"flex": "1 1 50%"
-						},
+						"devices[].name",
+						"devices[].exclude",
 						{
 							"type": "fieldset",
-							"title": "Basic settings",
+							"title": "More control",
 							"flex": "1 1 100%",
 							"expandable": true,
 							"expanded": false,
 							"items": [
-								{
-									"key": "devices[].disabled",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].mess",
-									"flex": "1 1 100%"
-								},
-								{
-									"key": "devices[].oscilateSwitch",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].autoMode",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].exposeOutdoorUnit",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].minHeatingTemperature",
-									"flex": "1 1 50%"
-								}
+								"devices[].oscilateSwitch",
+								"devices[].autoMode",
+								"devices[].forceSwing",
+								"devices[].forceNanoe",
+								"devices[].forceInsideCleaning",
+								"devices[].forceEcoNavi"
 							]
 						},
 						{
 							"type": "fieldset",
-							"title": "Force values",
+							"title": "Swing directions",
 							"flex": "1 1 100%",
 							"expandable": true,
 							"expanded": false,
 							"items": [
-								{
-									"key": "devices[].forceSwing",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].forceNanoe",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].forceInsideCleaning",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].forceEcoNavi",
-									"flex": "1 1 50%"
-								}
+								"devices[].swingModeDirections",
+								"devices[].swingModeDefaultPositionUpDown",
+								"devices[].swingModeDefaultPositionLeftRight"
 							]
 						},
 						{
 							"type": "fieldset",
-							"title": "Swing",
+							"title": "Other",
 							"flex": "1 1 100%",
 							"expandable": true,
 							"expanded": false,
 							"items": [
-								{
-									"key": "devices[].swingModeDirections",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].swingModeDefaultPositionUpDown",
-									"flex": "1 1 50%"
-								},
-								{
-									"key": "devices[].swingModeDefaultPositionLeftRight",
-									"flex": "1 1 50%"
-								}
+								"devices[].exposeOutdoorUnit",
+								"devices[].minHeatingTemperature"
 							]
 						}
 					]

--- a/config.schema.json
+++ b/config.schema.json
@@ -461,7 +461,7 @@
 			"type": "array",
 			"key": "devices",
 			"title": "Devices",
-			"description": "All devices are automatically added from Comfort Cloud. Here add only those devices for which you want to apply separate settings or devices that you want to exclude.",
+			"description": "All devices are automatically added from Comfort Cloud. Here add only those devices for which you want to apply separate settings.",
 			"buttonText": "Add device",
 			"expandable": true,
 			"expanded": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -434,7 +434,7 @@
 		{
 			"type": "fieldset",
 			"title": "Account",
-			"description": "Panasonic Comfort Cloud login details.",
+			"description": "Comfort Cloud (Panasonic ID) login details.",
 			"expandable": true,
 			"expanded": true,
 			"items": [

--- a/config.schema.json
+++ b/config.schema.json
@@ -201,7 +201,159 @@
 					{ "title": "Dry mode", "enum": ["dry"] }
 				],
 				"required": true
+			},
+			"devices": {
+				"type": "array",
+				"items": {
+				  "type": "object",
+				  "properties": {
+					"name": {
+					  "type": "string",
+					  "required": true,
+					  "description": "Device name or serial (E.G.: CS-Z50VKEW+2462503161)."
+					},
+					"mess": {
+					  "type": "string",
+					  "required": false
+					},
+					"disabled": {
+					  "type": "boolean",
+					  "description": "Exclude this device."
+					},
+					"exposeOutdoorUnit": {
+						"title": "Expose Outdoor Unit",
+						"description": "When enabled, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
+						"type": "boolean",
+						"default": false
+					},
+					"forceSwing" : {
+						"title": "Force Swing",
+						"description": "Swing value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+						"type": "string",
+						"default": "false",
+						"required": true,
+						"oneOf": [
+							{ "title": "Do nothing", "enum": ["false"] },
+							{ "title": "Set on", "enum": ["on"] },
+							{ "title": "Set off", "enum": ["off"] }
+						]
+					},
+					"forceNanoe" : {
+						"title": "Force Nanoe",
+						"description": "Nanoe value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+						"type": "string",
+						"default": "false",
+						"oneOf": [
+							{ "title": "Do nothing", "enum": ["false"] },
+							{ "title": "Set on", "enum": ["on"] },
+							{ "title": "Set off", "enum": ["off"] }
+						],
+						"required": true
+					},
+					"forceEcoNavi" : {
+						"title": "Force Eco Navi",
+						"description": "Eco Navi value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+						"type": "string",
+						"default": "false",
+						"oneOf": [
+							{ "title": "Do nothing", "enum": ["false"] },
+							{ "title": "Set on", "enum": ["on"] },
+							{ "title": "Set off", "enum": ["off"] }
+						],
+						"required": true
+					},
+					"forceInsideCleaning" : {
+						"title": "Force Inside Cleaning",
+						"description": "Inside Cleaning value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+						"type": "string",
+						"default": "false",
+						"oneOf": [
+							{ "title": "Do nothing", "enum": ["false"] },
+							{ "title": "Set on", "enum": ["on"] },
+							{ "title": "Set off", "enum": ["off"] }
+						],
+						"required": true
+					},
+					"oscilateSwitch" : {
+						"title": "Oscilate Switch",
+						"description": "Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.",
+						"type": "string",
+						"default": "swing",
+						"oneOf": [
+							{ "title": "Swing Mode", "enum": ["swing"] },
+							{ "title": "Nanoe", "enum": ["nanoe"] },
+							{ "title": "Eco Navi", "enum": ["ecoNavi"] },
+							{ "title": "Inside Cleaning", "enum": ["insideCleaning"] }
+						],
+						"required": true
+					},
+					"swingModeDirections" : {
+						"title": "Swing Mode Directions",
+						"description": "Swing direction(s) when activated via HomeKit (by 'Oscillate switch' or by 'Override Swing').",
+						"type": "string",
+						"default": "LEFT-RIGHT-UP-DOWN",
+						"oneOf": [
+							{ "title": "Left-Right and Up-Down", "enum": ["LEFT-RIGHT-UP-DOWN"] },
+							{ "title": "Left-Right only", "enum": ["LEFT-RIGHT"] },
+							{ "title": "Up-Down only", "enum": ["UP-DOWN"] }
+						],
+						"required": true
+					},
+					"swingModeDefaultPositionLeftRight" : {
+						"title": "Swing Mode Default Position (Left-Right)",
+						"description": "Position of the Left-Right flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
+						"type": "string",
+						"default": "CENTER",
+						"oneOf": [
+							{ "title": "Left", "enum": ["LEFT"] },
+							{ "title": "Center-Left", "enum": ["CENTER-LEFT"] },
+							{ "title": "Center", "enum": ["CENTER"] },
+							{ "title": "Center-Right", "enum": ["CENTER-RIGHT"] },
+							{ "title": "Right", "enum": ["RIGHT"] }
+						],
+						"required": true
+					},
+					"swingModeDefaultPositionUpDown" : {
+						"title": "Swing Mode Default Position (Up-Down)",
+						"description": "Position of the Up-Down flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
+						"type": "string",
+						"default": "CENTER",
+						"oneOf": [
+							{ "title": "Up", "enum": ["UP"] },
+							{ "title": "Center-Up", "enum": ["CENTER-UP"] },
+							{ "title": "Center", "enum": ["CENTER"] },
+							{ "title": "Center-Down", "enum": ["CENTER-DOWN"] },
+							{ "title": "Down", "enum": ["DOWN"] }
+						],
+						"required": true
+					},
+					"suppressOutgoingUpdates": {
+						"title": "Suppress outgoing device updates",
+						"description": "When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.",
+						"type": "boolean"
+					},
+					"minHeatingTemperature": {
+						"title": "Minimum heating temperature (override)",
+						"description": "The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
+						"type": "integer",
+						"placeholder": "16"
+					},
+					"autoMode" : {
+						"title": "Auto Mode",
+						"description": "Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
+						"type": "string",
+						"default": "auto",
+						"oneOf": [
+							{ "title": "Auto mode", "enum": ["auto"] },
+							{ "title": "Fan mode", "enum": ["fan"] },
+							{ "title": "Dry mode", "enum": ["dry"] }
+						],
+						"required": true
+					}
+				  }
+				}
 			}
+			
 		}
 	},
 	"layout": [
@@ -266,6 +418,126 @@
 				"suppressOutgoingUpdates",
 				"logsLevel"
 			]
+		},
+
+
+		{
+			"type": "array",
+			"key": "devices",
+			"title": "Devices",
+			"description": "All devices are automatically added from Comfort Cloud. Here add only those devices for which you want to apply separate settings or devices that you want to exclude.",
+			"buttonText": "Add device",
+			"expandable": true,
+			"expanded": false,
+			"items": [
+				
+			  {
+				"type": "div",
+				"displayFlex": true,
+				"flex-flow": "row wrap",
+				"items": [
+
+
+					
+
+				
+		
+				  
+
+					{
+						"key": "devices[].name",
+						"flex": "1 1 50%"
+					  },
+
+					{
+					"type": "fieldset",
+					"title": "Basic settings",
+					"flex": "1 1 100%",
+					"expandable": true,
+					"expanded": false,
+					"items": [
+						
+						  {
+							"key": "devices[].disabled",
+							"flex": "1 1 50%"
+							
+						  },
+						  {
+							"key": "devices[].mess",
+							"flex": "1 1 100%"
+						  },
+						  {
+							"key": "devices[].oscilateSwitch",
+							"flex": "1 1 50%"
+						  },
+						  {
+							"key": "devices[].autoMode",
+							"flex": "1 1 50%"
+						  },
+						  
+						  {
+							"key": "devices[].exposeOutdoorUnit",
+							"flex": "1 1 50%"
+						  },
+						  {
+							"key": "devices[].minHeatingTemperature",
+							"flex": "1 1 50%"
+						  }
+					]
+				  },
+				  
+				  {
+					"type": "fieldset",
+					"title": "Force values",
+					"flex": "1 1 100%",
+					"expandable": true,
+					"expanded": false,
+					"items": [
+						{
+							"key": "devices[].forceSwing",
+							"flex": "1 1 50%"
+						  },
+						  {
+							"key": "devices[].forceNanoe",
+							"flex": "1 1 50%"
+						  },
+						  {
+							"key": "devices[].forceInsideCleaning",
+							"flex": "1 1 50%"
+						  },
+						  {
+							"key": "devices[].forceEcoNavi",
+							"flex": "1 1 50%"
+						  }
+					]
+				  },
+				  
+				  {
+					"type": "fieldset",
+					"title": "Swing",
+					"flex": "1 1 100%",
+					"expandable": true,
+					"expanded": false,
+					"items": [
+						{
+							"key": "devices[].swingModeDirections",
+							"flex": "1 1 50%"
+						},
+						{
+							"key": "devices[].swingModeDefaultPositionUpDown",
+							"flex": "1 1 50%"
+						},
+						{
+							"key": "devices[].swingModeDefaultPositionLeftRight",
+							"flex": "1 1 50%"
+						}
+					]
+				  }
+				]
+			  }
+			]
 		}
+
+
 	]
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -470,7 +470,6 @@
 					"type": "fieldset",
 					"items": [
 						"devices[].name",
-						"devices[].exclude",
 						{
 							"type": "fieldset",
 							"title": "More control",

--- a/config.schema.json
+++ b/config.schema.json
@@ -140,11 +140,6 @@
 							"required": true,
 							"description": "Device name (as it is in Comfort Cloud account) or serial (E.G.: CS-Z50VKEW+2462503161)."
 						},
-						"exclude": {
-							"title": "Exclude device",
-							"type": "boolean",
-							"description": "Exclude this device from Homebridge and HomeKit. This will not remove device from Comfort Cloud."
-						},
 						"autoMode": {
 							"title": "Auto Mode",
 							"description": "HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",

--- a/config.schema.json
+++ b/config.schema.json
@@ -44,120 +44,300 @@
 				"type": "boolean",
 				"default": false
 			},
-			"startSwing" : {
+			"startSwing": {
 				"title": "Override Swing",
 				"description": "Swing value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
 				"type": "string",
 				"default": "false",
 				"required": true,
 				"oneOf": [
-					{ "title": "Do nothing", "enum": ["false"] },
-					{ "title": "Set on", "enum": ["on"] },
-					{ "title": "Set off", "enum": ["off"] }
+					{
+						"title": "Do nothing",
+						"enum": [
+							"false"
+						]
+					},
+					{
+						"title": "Set on",
+						"enum": [
+							"on"
+						]
+					},
+					{
+						"title": "Set off",
+						"enum": [
+							"off"
+						]
+					}
 				]
 			},
-			"startNanoe" : {
+			"startNanoe": {
 				"title": "Override Nanoe",
 				"description": "Nanoe value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
 				"type": "string",
 				"default": "false",
 				"oneOf": [
-					{ "title": "Do nothing", "enum": ["false"] },
-					{ "title": "Set on", "enum": ["on"] },
-					{ "title": "Set off", "enum": ["off"] }
+					{
+						"title": "Do nothing",
+						"enum": [
+							"false"
+						]
+					},
+					{
+						"title": "Set on",
+						"enum": [
+							"on"
+						]
+					},
+					{
+						"title": "Set off",
+						"enum": [
+							"off"
+						]
+					}
 				],
 				"required": true
 			},
-			"startEcoNavi" : {
+			"startEcoNavi": {
 				"title": "Override Eco Navi",
 				"description": "Eco Navi value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
 				"type": "string",
 				"default": "false",
 				"oneOf": [
-					{ "title": "Do nothing", "enum": ["false"] },
-					{ "title": "Set on", "enum": ["on"] },
-					{ "title": "Set off", "enum": ["off"] }
+					{
+						"title": "Do nothing",
+						"enum": [
+							"false"
+						]
+					},
+					{
+						"title": "Set on",
+						"enum": [
+							"on"
+						]
+					},
+					{
+						"title": "Set off",
+						"enum": [
+							"off"
+						]
+					}
 				],
 				"required": true
 			},
-			"startInsideCleaning" : {
+			"startInsideCleaning": {
 				"title": "Override Inside Cleaning",
 				"description": "Inside Cleaning value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
 				"type": "string",
 				"default": "false",
 				"oneOf": [
-					{ "title": "Do nothing", "enum": ["false"] },
-					{ "title": "Set on", "enum": ["on"] },
-					{ "title": "Set off", "enum": ["off"] }
+					{
+						"title": "Do nothing",
+						"enum": [
+							"false"
+						]
+					},
+					{
+						"title": "Set on",
+						"enum": [
+							"on"
+						]
+					},
+					{
+						"title": "Set off",
+						"enum": [
+							"off"
+						]
+					}
 				],
 				"required": true
 			},
-			"oscilateSwitch" : {
+			"oscilateSwitch": {
 				"title": "Oscilate Switch",
 				"description": "Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.",
 				"type": "string",
 				"default": "swing",
 				"oneOf": [
-					{ "title": "Swing Mode", "enum": ["swing"] },
-					{ "title": "Nanoe", "enum": ["nanoe"] },
-					{ "title": "Eco Navi", "enum": ["ecoNavi"] },
-					{ "title": "Inside Cleaning", "enum": ["insideCleaning"] }
+					{
+						"title": "Swing Mode",
+						"enum": [
+							"swing"
+						]
+					},
+					{
+						"title": "Nanoe",
+						"enum": [
+							"nanoe"
+						]
+					},
+					{
+						"title": "Eco Navi",
+						"enum": [
+							"ecoNavi"
+						]
+					},
+					{
+						"title": "Inside Cleaning",
+						"enum": [
+							"insideCleaning"
+						]
+					}
 				],
 				"required": true
 			},
-			"refreshInterval" : {
+			"refreshInterval": {
 				"title": "Refresh interval",
 				"type": "integer",
 				"description": "Note: More frequent refresh would result in too much daily number of requests to the Panasonic server, which could result in an account lock for 24 hours, or even a complete API lock.",
 				"required": true,
 				"default": 60,
 				"oneOf": [
-					{ "title": "Disabled", "enum": [0] },
-					{ "title": "10 minutes", "enum": [10] },
-					{ "title": "30 minutes", "enum": [30] },
-					{ "title": "1 hour", "enum": [60] },
-					{ "title": "6 hours", "enum": [360] },
-					{ "title": "12 hours", "enum": [720] },
-					{ "title": "1 day", "enum": [1440] }
+					{
+						"title": "Disabled",
+						"enum": [
+							0
+						]
+					},
+					{
+						"title": "10 minutes",
+						"enum": [
+							10
+						]
+					},
+					{
+						"title": "30 minutes",
+						"enum": [
+							30
+						]
+					},
+					{
+						"title": "1 hour",
+						"enum": [
+							60
+						]
+					},
+					{
+						"title": "6 hours",
+						"enum": [
+							360
+						]
+					},
+					{
+						"title": "12 hours",
+						"enum": [
+							720
+						]
+					},
+					{
+						"title": "1 day",
+						"enum": [
+							1440
+						]
+					}
 				]
 			},
-			"swingModeDirections" : {
+			"swingModeDirections": {
 				"title": "Swing Mode Directions",
 				"description": "Swing direction(s) when activated via HomeKit (by 'Oscillate switch' or by 'Override Swing').",
 				"type": "string",
 				"default": "LEFT-RIGHT-UP-DOWN",
 				"oneOf": [
-					{ "title": "Left-Right and Up-Down", "enum": ["LEFT-RIGHT-UP-DOWN"] },
-					{ "title": "Left-Right only", "enum": ["LEFT-RIGHT"] },
-					{ "title": "Up-Down only", "enum": ["UP-DOWN"] }
+					{
+						"title": "Left-Right and Up-Down",
+						"enum": [
+							"LEFT-RIGHT-UP-DOWN"
+						]
+					},
+					{
+						"title": "Left-Right only",
+						"enum": [
+							"LEFT-RIGHT"
+						]
+					},
+					{
+						"title": "Up-Down only",
+						"enum": [
+							"UP-DOWN"
+						]
+					}
 				],
 				"required": true
 			},
-			"swingModeDefaultPositionLeftRight" : {
+			"swingModeDefaultPositionLeftRight": {
 				"title": "Swing Mode Default Position (Left-Right)",
 				"description": "Position of the Left-Right flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
 				"type": "string",
 				"default": "CENTER",
 				"oneOf": [
-					{ "title": "Left", "enum": ["LEFT"] },
-					{ "title": "Center-Left", "enum": ["CENTER-LEFT"] },
-					{ "title": "Center", "enum": ["CENTER"] },
-					{ "title": "Center-Right", "enum": ["CENTER-RIGHT"] },
-					{ "title": "Right", "enum": ["RIGHT"] }
+					{
+						"title": "Left",
+						"enum": [
+							"LEFT"
+						]
+					},
+					{
+						"title": "Center-Left",
+						"enum": [
+							"CENTER-LEFT"
+						]
+					},
+					{
+						"title": "Center",
+						"enum": [
+							"CENTER"
+						]
+					},
+					{
+						"title": "Center-Right",
+						"enum": [
+							"CENTER-RIGHT"
+						]
+					},
+					{
+						"title": "Right",
+						"enum": [
+							"RIGHT"
+						]
+					}
 				],
 				"required": true
 			},
-			"swingModeDefaultPositionUpDown" : {
+			"swingModeDefaultPositionUpDown": {
 				"title": "Swing Mode Default Position (Up-Down)",
 				"description": "Position of the Up-Down flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
 				"type": "string",
 				"default": "CENTER",
 				"oneOf": [
-					{ "title": "Up", "enum": ["UP"] },
-					{ "title": "Center-Up", "enum": ["CENTER-UP"] },
-					{ "title": "Center", "enum": ["CENTER"] },
-					{ "title": "Center-Down", "enum": ["CENTER-DOWN"] },
-					{ "title": "Down", "enum": ["DOWN"] }
+					{
+						"title": "Up",
+						"enum": [
+							"UP"
+						]
+					},
+					{
+						"title": "Center-Up",
+						"enum": [
+							"CENTER-UP"
+						]
+					},
+					{
+						"title": "Center",
+						"enum": [
+							"CENTER"
+						]
+					},
+					{
+						"title": "Center-Down",
+						"enum": [
+							"CENTER-DOWN"
+						]
+					},
+					{
+						"title": "Down",
+						"enum": [
+							"DOWN"
+						]
+					}
 				],
 				"required": true
 			},
@@ -178,188 +358,377 @@
 				"type": "integer",
 				"placeholder": "16"
 			},
-			"logsLevel" : {
+			"logsLevel": {
 				"title": "Logs Level",
 				"description": "Logs level. Note: to see debug messages in logs it is also required to enable Debug in Homebridge Settings.",
 				"type": "integer",
 				"default": "1",
 				"oneOf": [
-					{ "title": "Only errors and important info", "enum": [0] },
-					{ "title": "Standard", "enum": [1] },
-					{ "title": "All (including debug)", "enum": [2] }
+					{
+						"title": "Only errors and important info",
+						"enum": [
+							0
+						]
+					},
+					{
+						"title": "Standard",
+						"enum": [
+							1
+						]
+					},
+					{
+						"title": "All (including debug)",
+						"enum": [
+							2
+						]
+					}
 				],
 				"required": true
 			},
-			"autoMode" : {
+			"autoMode": {
 				"title": "Auto Mode",
 				"description": "Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
 				"type": "string",
 				"default": "auto",
 				"oneOf": [
-					{ "title": "Auto mode", "enum": ["auto"] },
-					{ "title": "Fan mode", "enum": ["fan"] },
-					{ "title": "Dry mode", "enum": ["dry"] }
+					{
+						"title": "Auto mode",
+						"enum": [
+							"auto"
+						]
+					},
+					{
+						"title": "Fan mode",
+						"enum": [
+							"fan"
+						]
+					},
+					{
+						"title": "Dry mode",
+						"enum": [
+							"dry"
+						]
+					}
 				],
 				"required": true
 			},
 			"devices": {
 				"type": "array",
 				"items": {
-				  "type": "object",
-				  "properties": {
-					"name": {
-					  "type": "string",
-					  "required": true,
-					  "description": "Device name or serial (E.G.: CS-Z50VKEW+2462503161)."
-					},
-					"mess": {
-					  "type": "string",
-					  "required": false
-					},
-					"disabled": {
-					  "type": "boolean",
-					  "description": "Exclude this device."
-					},
-					"exposeOutdoorUnit": {
-						"title": "Expose Outdoor Unit",
-						"description": "When enabled, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
-						"type": "boolean",
-						"default": false
-					},
-					"forceSwing" : {
-						"title": "Force Swing",
-						"description": "Swing value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-						"type": "string",
-						"default": "false",
-						"required": true,
-						"oneOf": [
-							{ "title": "Do nothing", "enum": ["false"] },
-							{ "title": "Set on", "enum": ["on"] },
-							{ "title": "Set off", "enum": ["off"] }
-						]
-					},
-					"forceNanoe" : {
-						"title": "Force Nanoe",
-						"description": "Nanoe value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-						"type": "string",
-						"default": "false",
-						"oneOf": [
-							{ "title": "Do nothing", "enum": ["false"] },
-							{ "title": "Set on", "enum": ["on"] },
-							{ "title": "Set off", "enum": ["off"] }
-						],
-						"required": true
-					},
-					"forceEcoNavi" : {
-						"title": "Force Eco Navi",
-						"description": "Eco Navi value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-						"type": "string",
-						"default": "false",
-						"oneOf": [
-							{ "title": "Do nothing", "enum": ["false"] },
-							{ "title": "Set on", "enum": ["on"] },
-							{ "title": "Set off", "enum": ["off"] }
-						],
-						"required": true
-					},
-					"forceInsideCleaning" : {
-						"title": "Force Inside Cleaning",
-						"description": "Inside Cleaning value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-						"type": "string",
-						"default": "false",
-						"oneOf": [
-							{ "title": "Do nothing", "enum": ["false"] },
-							{ "title": "Set on", "enum": ["on"] },
-							{ "title": "Set off", "enum": ["off"] }
-						],
-						"required": true
-					},
-					"oscilateSwitch" : {
-						"title": "Oscilate Switch",
-						"description": "Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.",
-						"type": "string",
-						"default": "swing",
-						"oneOf": [
-							{ "title": "Swing Mode", "enum": ["swing"] },
-							{ "title": "Nanoe", "enum": ["nanoe"] },
-							{ "title": "Eco Navi", "enum": ["ecoNavi"] },
-							{ "title": "Inside Cleaning", "enum": ["insideCleaning"] }
-						],
-						"required": true
-					},
-					"swingModeDirections" : {
-						"title": "Swing Mode Directions",
-						"description": "Swing direction(s) when activated via HomeKit (by 'Oscillate switch' or by 'Override Swing').",
-						"type": "string",
-						"default": "LEFT-RIGHT-UP-DOWN",
-						"oneOf": [
-							{ "title": "Left-Right and Up-Down", "enum": ["LEFT-RIGHT-UP-DOWN"] },
-							{ "title": "Left-Right only", "enum": ["LEFT-RIGHT"] },
-							{ "title": "Up-Down only", "enum": ["UP-DOWN"] }
-						],
-						"required": true
-					},
-					"swingModeDefaultPositionLeftRight" : {
-						"title": "Swing Mode Default Position (Left-Right)",
-						"description": "Position of the Left-Right flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
-						"type": "string",
-						"default": "CENTER",
-						"oneOf": [
-							{ "title": "Left", "enum": ["LEFT"] },
-							{ "title": "Center-Left", "enum": ["CENTER-LEFT"] },
-							{ "title": "Center", "enum": ["CENTER"] },
-							{ "title": "Center-Right", "enum": ["CENTER-RIGHT"] },
-							{ "title": "Right", "enum": ["RIGHT"] }
-						],
-						"required": true
-					},
-					"swingModeDefaultPositionUpDown" : {
-						"title": "Swing Mode Default Position (Up-Down)",
-						"description": "Position of the Up-Down flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
-						"type": "string",
-						"default": "CENTER",
-						"oneOf": [
-							{ "title": "Up", "enum": ["UP"] },
-							{ "title": "Center-Up", "enum": ["CENTER-UP"] },
-							{ "title": "Center", "enum": ["CENTER"] },
-							{ "title": "Center-Down", "enum": ["CENTER-DOWN"] },
-							{ "title": "Down", "enum": ["DOWN"] }
-						],
-						"required": true
-					},
-					"suppressOutgoingUpdates": {
-						"title": "Suppress outgoing device updates",
-						"description": "When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.",
-						"type": "boolean"
-					},
-					"minHeatingTemperature": {
-						"title": "Minimum heating temperature (override)",
-						"description": "The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
-						"type": "integer",
-						"placeholder": "16"
-					},
-					"autoMode" : {
-						"title": "Auto Mode",
-						"description": "Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
-						"type": "string",
-						"default": "auto",
-						"oneOf": [
-							{ "title": "Auto mode", "enum": ["auto"] },
-							{ "title": "Fan mode", "enum": ["fan"] },
-							{ "title": "Dry mode", "enum": ["dry"] }
-						],
-						"required": true
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"required": true,
+							"description": "Device name or serial (E.G.: CS-Z50VKEW+2462503161)."
+						},
+						"mess": {
+							"type": "string",
+							"required": false
+						},
+						"disabled": {
+							"type": "boolean",
+							"description": "Exclude this device."
+						},
+						"exposeOutdoorUnit": {
+							"title": "Expose Outdoor Unit",
+							"description": "When enabled, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
+							"type": "boolean",
+							"default": false
+						},
+						"forceSwing": {
+							"title": "Force Swing",
+							"description": "Swing value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+							"type": "string",
+							"default": "false",
+							"required": true,
+							"oneOf": [
+								{
+									"title": "Do nothing",
+									"enum": [
+										"false"
+									]
+								},
+								{
+									"title": "Set on",
+									"enum": [
+										"on"
+									]
+								},
+								{
+									"title": "Set off",
+									"enum": [
+										"off"
+									]
+								}
+							]
+						},
+						"forceNanoe": {
+							"title": "Force Nanoe",
+							"description": "Nanoe value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+							"type": "string",
+							"default": "false",
+							"oneOf": [
+								{
+									"title": "Do nothing",
+									"enum": [
+										"false"
+									]
+								},
+								{
+									"title": "Set on",
+									"enum": [
+										"on"
+									]
+								},
+								{
+									"title": "Set off",
+									"enum": [
+										"off"
+									]
+								}
+							],
+							"required": true
+						},
+						"forceEcoNavi": {
+							"title": "Force Eco Navi",
+							"description": "Eco Navi value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+							"type": "string",
+							"default": "false",
+							"oneOf": [
+								{
+									"title": "Do nothing",
+									"enum": [
+										"false"
+									]
+								},
+								{
+									"title": "Set on",
+									"enum": [
+										"on"
+									]
+								},
+								{
+									"title": "Set off",
+									"enum": [
+										"off"
+									]
+								}
+							],
+							"required": true
+						},
+						"forceInsideCleaning": {
+							"title": "Force Inside Cleaning",
+							"description": "Inside Cleaning value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+							"type": "string",
+							"default": "false",
+							"oneOf": [
+								{
+									"title": "Do nothing",
+									"enum": [
+										"false"
+									]
+								},
+								{
+									"title": "Set on",
+									"enum": [
+										"on"
+									]
+								},
+								{
+									"title": "Set off",
+									"enum": [
+										"off"
+									]
+								}
+							],
+							"required": true
+						},
+						"oscilateSwitch": {
+							"title": "Oscilate Switch",
+							"description": "Decide what the switch should control: Swing Mode, Nanoe, Eco Navi or Inside Cleaning.",
+							"type": "string",
+							"default": "swing",
+							"oneOf": [
+								{
+									"title": "Swing Mode",
+									"enum": [
+										"swing"
+									]
+								},
+								{
+									"title": "Nanoe",
+									"enum": [
+										"nanoe"
+									]
+								},
+								{
+									"title": "Eco Navi",
+									"enum": [
+										"ecoNavi"
+									]
+								},
+								{
+									"title": "Inside Cleaning",
+									"enum": [
+										"insideCleaning"
+									]
+								}
+							],
+							"required": true
+						},
+						"swingModeDirections": {
+							"title": "Swing Mode Directions",
+							"description": "Swing direction(s) when activated via HomeKit (by 'Oscillate switch' or by 'Override Swing').",
+							"type": "string",
+							"default": "LEFT-RIGHT-UP-DOWN",
+							"oneOf": [
+								{
+									"title": "Left-Right and Up-Down",
+									"enum": [
+										"LEFT-RIGHT-UP-DOWN"
+									]
+								},
+								{
+									"title": "Left-Right only",
+									"enum": [
+										"LEFT-RIGHT"
+									]
+								},
+								{
+									"title": "Up-Down only",
+									"enum": [
+										"UP-DOWN"
+									]
+								}
+							],
+							"required": true
+						},
+						"swingModeDefaultPositionLeftRight": {
+							"title": "Swing Mode Default Position (Left-Right)",
+							"description": "Position of the Left-Right flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
+							"type": "string",
+							"default": "CENTER",
+							"oneOf": [
+								{
+									"title": "Left",
+									"enum": [
+										"LEFT"
+									]
+								},
+								{
+									"title": "Center-Left",
+									"enum": [
+										"CENTER-LEFT"
+									]
+								},
+								{
+									"title": "Center",
+									"enum": [
+										"CENTER"
+									]
+								},
+								{
+									"title": "Center-Right",
+									"enum": [
+										"CENTER-RIGHT"
+									]
+								},
+								{
+									"title": "Right",
+									"enum": [
+										"RIGHT"
+									]
+								}
+							],
+							"required": true
+						},
+						"swingModeDefaultPositionUpDown": {
+							"title": "Swing Mode Default Position (Up-Down)",
+							"description": "Position of the Up-Down flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
+							"type": "string",
+							"default": "CENTER",
+							"oneOf": [
+								{
+									"title": "Up",
+									"enum": [
+										"UP"
+									]
+								},
+								{
+									"title": "Center-Up",
+									"enum": [
+										"CENTER-UP"
+									]
+								},
+								{
+									"title": "Center",
+									"enum": [
+										"CENTER"
+									]
+								},
+								{
+									"title": "Center-Down",
+									"enum": [
+										"CENTER-DOWN"
+									]
+								},
+								{
+									"title": "Down",
+									"enum": [
+										"DOWN"
+									]
+								}
+							],
+							"required": true
+						},
+						"suppressOutgoingUpdates": {
+							"title": "Suppress outgoing device updates",
+							"description": "When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.",
+							"type": "boolean"
+						},
+						"minHeatingTemperature": {
+							"title": "Minimum heating temperature (override)",
+							"description": "The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
+							"type": "integer",
+							"placeholder": "16"
+						},
+						"autoMode": {
+							"title": "Auto Mode",
+							"description": "Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
+							"type": "string",
+							"default": "auto",
+							"oneOf": [
+								{
+									"title": "Auto mode",
+									"enum": [
+										"auto"
+									]
+								},
+								{
+									"title": "Fan mode",
+									"enum": [
+										"fan"
+									]
+								},
+								{
+									"title": "Dry mode",
+									"enum": [
+										"dry"
+									]
+								}
+							],
+							"required": true
+						}
 					}
-				  }
 				}
 			}
-			
 		}
 	},
 	"layout": [
 		{
 			"type": "fieldset",
-		  	"title": "Basic settings",
+			"title": "Basic settings",
 			"description": "Enter your Panasonic Comfort Cloud login details. It is recommended to set up a separate account for Homebridge and share the devices from your main account.",
 			"expandable": true,
 			"expanded": true,
@@ -381,7 +750,9 @@
 				{
 					"type": "flex",
 					"flex-flow": "row wrap",
-					"items": ["key2fa"]
+					"items": [
+						"key2fa"
+					]
 				}
 			]
 		},
@@ -419,8 +790,6 @@
 				"logsLevel"
 			]
 		},
-
-
 		{
 			"type": "array",
 			"key": "devices",
@@ -430,114 +799,97 @@
 			"expandable": true,
 			"expanded": false,
 			"items": [
-				
-			  {
-				"type": "div",
-				"displayFlex": true,
-				"flex-flow": "row wrap",
-				"items": [
-
-
-					
-
-				
-		
-				  
-
-					{
-						"key": "devices[].name",
-						"flex": "1 1 50%"
-					  },
-
-					{
-					"type": "fieldset",
-					"title": "Basic settings",
-					"flex": "1 1 100%",
-					"expandable": true,
-					"expanded": false,
-					"items": [
-						
-						  {
-							"key": "devices[].disabled",
-							"flex": "1 1 50%"
-							
-						  },
-						  {
-							"key": "devices[].mess",
-							"flex": "1 1 100%"
-						  },
-						  {
-							"key": "devices[].oscilateSwitch",
-							"flex": "1 1 50%"
-						  },
-						  {
-							"key": "devices[].autoMode",
-							"flex": "1 1 50%"
-						  },
-						  
-						  {
-							"key": "devices[].exposeOutdoorUnit",
-							"flex": "1 1 50%"
-						  },
-						  {
-							"key": "devices[].minHeatingTemperature",
-							"flex": "1 1 50%"
-						  }
-					]
-				  },
-				  
-				  {
-					"type": "fieldset",
-					"title": "Force values",
-					"flex": "1 1 100%",
-					"expandable": true,
-					"expanded": false,
+				{
+					"type": "div",
+					"displayFlex": true,
+					"flex-flow": "row wrap",
 					"items": [
 						{
-							"key": "devices[].forceSwing",
-							"flex": "1 1 50%"
-						  },
-						  {
-							"key": "devices[].forceNanoe",
-							"flex": "1 1 50%"
-						  },
-						  {
-							"key": "devices[].forceInsideCleaning",
-							"flex": "1 1 50%"
-						  },
-						  {
-							"key": "devices[].forceEcoNavi",
-							"flex": "1 1 50%"
-						  }
-					]
-				  },
-				  
-				  {
-					"type": "fieldset",
-					"title": "Swing",
-					"flex": "1 1 100%",
-					"expandable": true,
-					"expanded": false,
-					"items": [
-						{
-							"key": "devices[].swingModeDirections",
+							"key": "devices[].name",
 							"flex": "1 1 50%"
 						},
 						{
-							"key": "devices[].swingModeDefaultPositionUpDown",
-							"flex": "1 1 50%"
+							"type": "fieldset",
+							"title": "Basic settings",
+							"flex": "1 1 100%",
+							"expandable": true,
+							"expanded": false,
+							"items": [
+								{
+									"key": "devices[].disabled",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].mess",
+									"flex": "1 1 100%"
+								},
+								{
+									"key": "devices[].oscilateSwitch",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].autoMode",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].exposeOutdoorUnit",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].minHeatingTemperature",
+									"flex": "1 1 50%"
+								}
+							]
 						},
 						{
-							"key": "devices[].swingModeDefaultPositionLeftRight",
-							"flex": "1 1 50%"
+							"type": "fieldset",
+							"title": "Force values",
+							"flex": "1 1 100%",
+							"expandable": true,
+							"expanded": false,
+							"items": [
+								{
+									"key": "devices[].forceSwing",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].forceNanoe",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].forceInsideCleaning",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].forceEcoNavi",
+									"flex": "1 1 50%"
+								}
+							]
+						},
+						{
+							"type": "fieldset",
+							"title": "Swing",
+							"flex": "1 1 100%",
+							"expandable": true,
+							"expanded": false,
+							"items": [
+								{
+									"key": "devices[].swingModeDirections",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].swingModeDefaultPositionUpDown",
+									"flex": "1 1 50%"
+								},
+								{
+									"key": "devices[].swingModeDefaultPositionLeftRight",
+									"flex": "1 1 50%"
+								}
+							]
 						}
 					]
-				  }
-				]
-			  }
+				}
 			]
 		}
-
-
 	]
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -4,7 +4,7 @@
 	"singular": true,
 	"schema": {
 		"type": "object",
-		"properties": {		
+		"properties": {
 			"email": {
 				"title": "Email",
 				"type": "string",
@@ -446,7 +446,6 @@
 				"key2fa"
 			]
 		},
-		
 		{
 			"type": "fieldset",
 			"title": "Advanced",

--- a/config.schema.json
+++ b/config.schema.json
@@ -434,7 +434,7 @@
 		{
 			"type": "fieldset",
 			"title": "Account",
-			"description": "Enter your Panasonic Comfort Cloud login details.",
+			"description": "Panasonic Comfort Cloud login details.",
 			"expandable": true,
 			"expanded": true,
 			"items": [

--- a/config.schema.json
+++ b/config.schema.json
@@ -10,13 +10,15 @@
 				"type": "string",
 				"placeholder": "Email",
 				"required": true,
-				"format": "email"
+				"format": "email",
+				"description": "The username of your Comfort Cloud (Panasonic ID) account."
 			},
 			"password": {
 				"title": "Password",
 				"type": "string",
 				"placeholder": "Password",
-				"required": true
+				"required": true,
+				"description": "The password of your Comfort Cloud (Panasonic ID) account."
 			},
 			"key2fa": {
 				"title": "2FA key",
@@ -26,7 +28,7 @@
 			},
 			"name": {
 				"title": "Plugin Name",
-				"description": "This name will be displayed in the Homebridge log.",
+				"description": "Name of the plugin in Homebridge log.",
 				"type": "string",
 				"default": "Homebridge Panasonic AC Platform",
 				"placeholder": "Homebridge Panasonic AC Platform",
@@ -143,115 +145,28 @@
 							"type": "boolean",
 							"description": "Exclude this device from Homebridge and HomeKit. This will not remove device from Comfort Cloud."
 						},
-						"exposeOutdoorUnit": {
-							"title": "Expose Outdoor Unit",
-							"description": "When enabled, the plugin will create a dummy temperature accessory which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
-							"type": "boolean",
-							"default": false
-						},
-						"forceSwing": {
-							"title": "Force Swing",
-							"description": "Swing value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
+						"autoMode": {
+							"title": "Auto Mode",
+							"description": "HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
 							"type": "string",
-							"default": "false",
-							"required": true,
+							"default": "auto",
 							"oneOf": [
 								{
-									"title": "Do nothing",
+									"title": "Auto mode",
 									"enum": [
-										"false"
+										"auto"
 									]
 								},
 								{
-									"title": "Set on",
+									"title": "Fan mode",
 									"enum": [
-										"on"
+										"fan"
 									]
 								},
 								{
-									"title": "Set off",
+									"title": "Dry mode",
 									"enum": [
-										"off"
-									]
-								}
-							]
-						},
-						"forceNanoe": {
-							"title": "Force Nanoe",
-							"description": "Nanoe value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-							"type": "string",
-							"default": "false",
-							"oneOf": [
-								{
-									"title": "Do nothing",
-									"enum": [
-										"false"
-									]
-								},
-								{
-									"title": "Set on",
-									"enum": [
-										"on"
-									]
-								},
-								{
-									"title": "Set off",
-									"enum": [
-										"off"
-									]
-								}
-							],
-							"required": true
-						},
-						"forceEcoNavi": {
-							"title": "Force Eco Navi",
-							"description": "Eco Navi value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-							"type": "string",
-							"default": "false",
-							"oneOf": [
-								{
-									"title": "Do nothing",
-									"enum": [
-										"false"
-									]
-								},
-								{
-									"title": "Set on",
-									"enum": [
-										"on"
-									]
-								},
-								{
-									"title": "Set off",
-									"enum": [
-										"off"
-									]
-								}
-							],
-							"required": true
-						},
-						"forceInsideCleaning": {
-							"title": "Force Inside Cleaning",
-							"description": "Inside Cleaning value with each state change made with HomeKit (e.g. activation): do nothing, set on, set off.",
-							"type": "string",
-							"default": "false",
-							"oneOf": [
-								{
-									"title": "Do nothing",
-									"enum": [
-										"false"
-									]
-								},
-								{
-									"title": "Set on",
-									"enum": [
-										"on"
-									]
-								},
-								{
-									"title": "Set off",
-									"enum": [
-										"off"
+										"dry"
 									]
 								}
 							],
@@ -290,6 +205,114 @@
 							],
 							"required": true
 						},
+						"forceSwing": {
+							"title": "Force Swing",
+							"description": "Swing value with each state change made with HomeKit (e.g. activation).",
+							"type": "string",
+							"default": "false",
+							"required": true,
+							"oneOf": [
+								{
+									"title": "Do nothing",
+									"enum": [
+										"false"
+									]
+								},
+								{
+									"title": "Set on",
+									"enum": [
+										"on"
+									]
+								},
+								{
+									"title": "Set off",
+									"enum": [
+										"off"
+									]
+								}
+							]
+						},
+						"forceNanoe": {
+							"title": "Force Nanoe",
+							"description": "Nanoe value with each state change made with HomeKit (e.g. activation).",
+							"type": "string",
+							"default": "false",
+							"oneOf": [
+								{
+									"title": "Do nothing",
+									"enum": [
+										"false"
+									]
+								},
+								{
+									"title": "Set on",
+									"enum": [
+										"on"
+									]
+								},
+								{
+									"title": "Set off",
+									"enum": [
+										"off"
+									]
+								}
+							],
+							"required": true
+						},
+						"forceEcoNavi": {
+							"title": "Force Eco Navi",
+							"description": "Eco Navi value with each state change made with HomeKit (e.g. activation).",
+							"type": "string",
+							"default": "false",
+							"oneOf": [
+								{
+									"title": "Do nothing",
+									"enum": [
+										"false"
+									]
+								},
+								{
+									"title": "Set on",
+									"enum": [
+										"on"
+									]
+								},
+								{
+									"title": "Set off",
+									"enum": [
+										"off"
+									]
+								}
+							],
+							"required": true
+						},
+						"forceInsideCleaning": {
+							"title": "Force Inside Cleaning",
+							"description": "Inside Cleaning value with each state change made with HomeKit (e.g. activation).",
+							"type": "string",
+							"default": "false",
+							"oneOf": [
+								{
+									"title": "Do nothing",
+									"enum": [
+										"false"
+									]
+								},
+								{
+									"title": "Set on",
+									"enum": [
+										"on"
+									]
+								},
+								{
+									"title": "Set off",
+									"enum": [
+										"off"
+									]
+								}
+							],
+							"required": true
+						},
 						"swingModeDirections": {
 							"title": "Swing Mode Directions",
 							"description": "Swing direction(s) when activated via HomeKit (by 'Oscillate switch' or by 'Override Swing').",
@@ -312,45 +335,6 @@
 									"title": "Up-Down only",
 									"enum": [
 										"UP-DOWN"
-									]
-								}
-							],
-							"required": true
-						},
-						"swingModeDefaultPositionLeftRight": {
-							"title": "Swing Mode Default Position (Left-Right)",
-							"description": "Position of the Left-Right flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
-							"type": "string",
-							"default": "CENTER",
-							"oneOf": [
-								{
-									"title": "Left",
-									"enum": [
-										"LEFT"
-									]
-								},
-								{
-									"title": "Center-Left",
-									"enum": [
-										"CENTER-LEFT"
-									]
-								},
-								{
-									"title": "Center",
-									"enum": [
-										"CENTER"
-									]
-								},
-								{
-									"title": "Center-Right",
-									"enum": [
-										"CENTER-RIGHT"
-									]
-								},
-								{
-									"title": "Right",
-									"enum": [
-										"RIGHT"
 									]
 								}
 							],
@@ -395,38 +379,56 @@
 							],
 							"required": true
 						},
+						"swingModeDefaultPositionLeftRight": {
+							"title": "Swing Mode Default Position (Left-Right)",
+							"description": "Position of the Left-Right flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
+							"type": "string",
+							"default": "CENTER",
+							"oneOf": [
+								{
+									"title": "Left",
+									"enum": [
+										"LEFT"
+									]
+								},
+								{
+									"title": "Center-Left",
+									"enum": [
+										"CENTER-LEFT"
+									]
+								},
+								{
+									"title": "Center",
+									"enum": [
+										"CENTER"
+									]
+								},
+								{
+									"title": "Center-Right",
+									"enum": [
+										"CENTER-RIGHT"
+									]
+								},
+								{
+									"title": "Right",
+									"enum": [
+										"RIGHT"
+									]
+								}
+							],
+							"required": true
+						},
+						"exposeOutdoorUnit": {
+							"title": "Expose Outdoor Unit",
+							"description": "When enabled, the plugin will create a dummy temperature accessory which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.",
+							"type": "boolean",
+							"default": false
+						},
 						"minHeatingTemperature": {
 							"title": "Minimum heating temperature (override)",
 							"description": "The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. You can use this setting to adjust the minimum value. Leave it empty to use the default value.",
 							"type": "integer",
 							"placeholder": "16"
-						},
-						"autoMode": {
-							"title": "Auto Mode",
-							"description": "HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
-							"type": "string",
-							"default": "auto",
-							"oneOf": [
-								{
-									"title": "Auto mode",
-									"enum": [
-										"auto"
-									]
-								},
-								{
-									"title": "Fan mode",
-									"enum": [
-										"fan"
-									]
-								},
-								{
-									"title": "Dry mode",
-									"enum": [
-										"dry"
-									]
-								}
-							],
-							"required": true
 						}
 					}
 				}

--- a/config.schema.json
+++ b/config.schema.json
@@ -140,6 +140,12 @@
 							"required": true,
 							"description": "Device name (as it is in Comfort Cloud account) or serial (E.G.: CS-Z50VKEW+2462503161)."
 						},
+						"excludeDevice": {
+							"title": "ExcludeDevice",
+							"description": "Exclude device from Homebridge and HomeKit (it will stay in Comfort Cloud).",
+							"type": "boolean",
+							"default": false
+						},
 						"autoMode": {
 							"title": "Auto Mode",
 							"description": "HomeKit has only 3 modes: Auto, Cool, Heat but Panasonic additionally has Fan and Dry. Choose what mode to be turned on after selecting the Auto mode in HomeKit: Fan mode, Dry mode or Auto mode (by default).",
@@ -470,6 +476,7 @@
 					"type": "fieldset",
 					"items": [
 						"devices[].name",
+						"devices[].excludeDevice",
 						{
 							"type": "fieldset",
 							"title": "More control",

--- a/config.schema.json
+++ b/config.schema.json
@@ -315,7 +315,7 @@
 						},
 						"swingModeDirections": {
 							"title": "Swing Mode Directions",
-							"description": "Swing direction(s) when activated via HomeKit (by 'Oscillate switch' or by 'Override Swing').",
+							"description": "Desired swing direction(s) activated when swing is switched on.",
 							"type": "string",
 							"default": "LEFT-RIGHT-UP-DOWN",
 							"oneOf": [
@@ -342,7 +342,7 @@
 						},
 						"swingModeDefaultPositionUpDown": {
 							"title": "Swing Mode Default Position (Up-Down)",
-							"description": "Position of the Up-Down flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
+							"description": "Desired position of the Up-Down flaps when swing is switched off or the swing directions setting is Left-Right only.",
 							"type": "string",
 							"default": "CENTER",
 							"oneOf": [
@@ -381,7 +381,7 @@
 						},
 						"swingModeDefaultPositionLeftRight": {
 							"title": "Swing Mode Default Position (Left-Right)",
-							"description": "Position of the Left-Right flaps when Swing Mode is deactivated via HomeKit (by 'Oscillate switch' or 'Override Swing').",
+							"description": "Desired position of the Left-Right flaps when swing is switched off or the swing directions setting is Up-Down only.",
 							"type": "string",
 							"default": "CENTER",
 							"oneOf": [

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -127,6 +127,9 @@ export default class IndoorUnitAccessory {
     let logOutput = '';
     this.platform.log.debug(`${this.accessory.displayName}: refresh status`);
 
+    const item = this.platform.platformConfig.devices.find((item) => item.name === this.accessory.displayName)
+      || this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceGuid) || {};
+
     try {
       const deviceStatus = await this.platform.comfortCloud.getDeviceStatus(
         this.accessory.context.device.deviceGuid);
@@ -328,7 +331,7 @@ export default class IndoorUnitAccessory {
         .updateValue(sliderValue);
 
       // Swing Mode
-      if (this.platform.platformConfig.oscilateSwitch === 'nanoe') {
+      if (item.oscilateSwitch === 'nanoe') {
         if (deviceStatus.nanoe === 2) {
           this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
             .updateValue(this.platform.Characteristic.SwingMode.SWING_ENABLED);
@@ -338,7 +341,7 @@ export default class IndoorUnitAccessory {
             .updateValue(this.platform.Characteristic.SwingMode.SWING_DISABLED);
           logOutput += 'Nanoe Off';
         }
-      } else if (this.platform.platformConfig.oscilateSwitch === 'ecoNavi') {
+      } else if (item.oscilateSwitch === 'ecoNavi') {
         if (deviceStatus.ecoNavi === 2 || deviceStatus.ecoFunctionData === 2) {
           this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
             .updateValue(this.platform.Characteristic.SwingMode.SWING_ENABLED);
@@ -348,7 +351,7 @@ export default class IndoorUnitAccessory {
             .updateValue(this.platform.Characteristic.SwingMode.SWING_DISABLED);
           logOutput += 'Eco Navi Off';
         }
-      } else if (this.platform.platformConfig.oscilateSwitch === 'insideCleaning') {
+      } else if (item.oscilateSwitch === 'insideCleaning') {
         if (deviceStatus.insideCleaning === 2) {
           this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
             .updateValue(this.platform.Characteristic.SwingMode.SWING_ENABLED);
@@ -359,12 +362,12 @@ export default class IndoorUnitAccessory {
           logOutput += 'Inside Cleaning Off';
         }
       } else if ((deviceStatus.fanAutoMode === ComfortCloudFanAutoMode.AirSwingAuto
-        && this.platform.platformConfig.swingModeDirections
+        && item.swingModeDirections
         === SwingModeDirection.LeftRightAndUpDown)
         || (deviceStatus.fanAutoMode === ComfortCloudFanAutoMode.AirSwingLR
-          && this.platform.platformConfig.swingModeDirections === SwingModeDirection.LeftRightOnly)
+          && item.swingModeDirections === SwingModeDirection.LeftRightOnly)
         || (deviceStatus.fanAutoMode === ComfortCloudFanAutoMode.AirSwingUD
-          && this.platform.platformConfig.swingModeDirections === SwingModeDirection.UpDownOnly)) {
+          && item.swingModeDirections === SwingModeDirection.UpDownOnly)) {
         this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
           .updateValue(this.platform.Characteristic.SwingMode.SWING_ENABLED);
         logOutput += 'Swing Mode On';

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -430,9 +430,9 @@ export default class IndoorUnitAccessory {
    * for example, turning on a Light bulb.
    */
   async setActive(value: CharacteristicValue) {
-    const devConfig = this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceName) ||
-        this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceGuid) || {};
-    
+    const devConfig = this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceName)
+      || this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceGuid) || {};
+
     this.platform.log.debug(`Accessory: setActive() for device '${this.accessory.displayName}'`);
     const parameters: ComfortCloudDeviceUpdatePayload = {
       operate: value === this.platform.Characteristic.Active.ACTIVE ? 1 : 0,

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -105,8 +105,8 @@ export default class IndoorUnitAccessory {
       .onSet(this.setThresholdTemperature.bind(this));
 
     // Heating Threshold Temperature (optional)
-    const item = this.platform.platformConfig.devices.find((item) => item.name === _d.deviceName) ||
-        this.platform.platformConfig.devices.find((item) => item.name === _c.deviceGuid) || {};
+    const item = this.platform.platformConfig.devices.find((item) => item.name === accessory.context.device?.deviceName)
+      || this.platform.platformConfig.devices.find((item) => item.name === accessory.context.device?.deviceGuid) || {};
     this.service
       .getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .setProps({

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -170,10 +170,10 @@ export default class IndoorUnitAccessory {
       }
 
       // Outdoor temperature
-      // Only check and set if the user wants to display the outdoor unit as separate device.
+      // Only check and set if the user wants to display the dummy sensor showing temp from outdoor unit.
       if (this.connectedOutdoorUnit) {
         if (deviceStatus.outTemperature >= 126) {
-          this.platform.log.error('Outdoor temperature is not available');
+          this.platform.log.info('Outdoor temperature is not available');
         } else {
           // Update the value of the connected outdoor unit
           this.connectedOutdoorUnit.setOutdoorTemperature(deviceStatus.outTemperature);
@@ -607,6 +607,11 @@ export default class IndoorUnitAccessory {
   }
 
   async setSwingMode(value: CharacteristicValue) {
+
+    // Individual confog for device (if exists).
+    const devConfig = this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceName)
+      || this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceGuid) || {};
+    
     this.platform.log.debug(
       `Accessory: setSwingMode() for device '${this.accessory.displayName}'`);
 
@@ -615,18 +620,18 @@ export default class IndoorUnitAccessory {
     if (value === this.platform.Characteristic.SwingMode.SWING_ENABLED) {
       // Activate swing mode
       // and (if needed) reset one set of fins to their default position.
-      if (this.platform.platformConfig.oscilateSwitch === 'nanoe') {
+      if (devConfig.oscilateSwitch === 'nanoe') {
         parameters.nanoe = 2;
         this.platform.log.debug(`${this.accessory.displayName}: Nanoe On`);
-      } else if (this.platform.platformConfig.oscilateSwitch === 'ecoNavi') {
+      } else if (devConfig.oscilateSwitch === 'ecoNavi') {
         parameters.ecoNavi = 2;
         parameters.ecoFunctionData = 2;
         this.platform.log.debug(`${this.accessory.displayName}: Eco Navi On`);
-      } else if (this.platform.platformConfig.oscilateSwitch === 'insideCleaning') {
+      } else if (devConfig.oscilateSwitch === 'insideCleaning') {
         parameters.insideCleaning = 2;
         this.platform.log.debug(`${this.accessory.displayName}: Inside Cleaning On`);
       } else {
-        switch (this.platform.platformConfig.swingModeDirections) {
+        switch (devConfig.swingModeDirections) {
           case SwingModeDirection.LeftRightAndUpDown:
             parameters.fanAutoMode = ComfortCloudFanAutoMode.AirSwingAuto;
             this.platform.log.debug(
@@ -652,14 +657,14 @@ export default class IndoorUnitAccessory {
       }
 
     } else if (value === this.platform.Characteristic.SwingMode.SWING_DISABLED) {
-      if (this.platform.platformConfig.oscilateSwitch === 'nanoe') {
+      if (devConfig.oscilateSwitch === 'nanoe') {
         parameters.nanoe = 1;
         this.platform.log.debug(`${this.accessory.displayName}: Nanoe Off`);
-      } else if (this.platform.platformConfig.oscilateSwitch === 'ecoNavi') {
+      } else if (devConfig.oscilateSwitch === 'ecoNavi') {
         parameters.ecoNavi = 1;
         parameters.ecoFunctionData = 1;
         this.platform.log.debug(`${this.accessory.displayName}: Eco Navi Off`);
-      } else if (this.platform.platformConfig.oscilateSwitch === 'insideCleaning') {
+      } else if (devConfig.oscilateSwitch === 'insideCleaning') {
         parameters.insideCleaning = 0;
         this.platform.log.debug(`${this.accessory.displayName}: Inside Cleaning Off`);
       } else {

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -105,10 +105,12 @@ export default class IndoorUnitAccessory {
       .onSet(this.setThresholdTemperature.bind(this));
 
     // Heating Threshold Temperature (optional)
+    const item = this.platform.platformConfig.devices.find((item) => item.name === _d.deviceName) ||
+        this.platform.platformConfig.devices.find((item) => item.name === _c.deviceGuid) || {};
     this.service
       .getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .setProps({
-        minValue: this.platform.platformConfig.minHeatingTemperature || 16,
+        minValue: item.minHeatingTemperature || 16,
         maxValue: 30,
         minStep: 0.5,
       })

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -105,8 +105,11 @@ export default class IndoorUnitAccessory {
       .onSet(this.setThresholdTemperature.bind(this));
 
     // Heating Threshold Temperature (optional)
+    
+    // Individual config for each device (if exists).
     const devConfig = this.platform.platformConfig.devices.find((item) => item.name === accessory.context.device?.deviceName)
       || this.platform.platformConfig.devices.find((item) => item.name === accessory.context.device?.deviceGuid) || {};
+    
     this.service
       .getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .setProps({
@@ -127,7 +130,8 @@ export default class IndoorUnitAccessory {
     let logOutput = '';
     this.platform.log.debug(`${this.accessory.displayName}: refresh status`);
 
-    const devConfig = this.platform.platformConfig.devices.find((item) => item.name === this.accessory.displayName)
+    // Individual config for each device (if exists).
+    const devConfig = this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceName)
       || this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceGuid) || {};
 
     try {
@@ -430,6 +434,7 @@ export default class IndoorUnitAccessory {
    * for example, turning on a Light bulb.
    */
   async setActive(value: CharacteristicValue) {
+    // Individual config for each device (if exists).
     const devConfig = this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceName)
       || this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceGuid) || {};
 
@@ -608,10 +613,10 @@ export default class IndoorUnitAccessory {
 
   async setSwingMode(value: CharacteristicValue) {
 
-    // Individual confog for device (if exists).
+    // Individual config for each device (if exists).
     const devConfig = this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceName)
       || this.platform.platformConfig.devices.find((item) => item.name === this.accessory.context.device.deviceGuid) || {};
-    
+
     this.platform.log.debug(
       `Accessory: setSwingMode() for device '${this.accessory.displayName}'`);
 

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -105,11 +105,11 @@ export default class IndoorUnitAccessory {
       .onSet(this.setThresholdTemperature.bind(this));
 
     // Heating Threshold Temperature (optional)
-    
+
     // Individual config for each device (if exists).
     const devConfig = this.platform.platformConfig.devices.find((item) => item.name === accessory.context.device?.deviceName)
       || this.platform.platformConfig.devices.find((item) => item.name === accessory.context.device?.deviceGuid) || {};
-    
+
     this.service
       .getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .setProps({

--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -83,6 +83,7 @@ export default class ComfortCloudApi {
       .catch((error: AxiosError) => {
         this.log.error('Comfort Cloud - login(): Error');
         this.log.debug(JSON.stringify(error, null, 2));
+        return Promise.reject(error);
       });
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -133,7 +133,6 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
       .then(() => {
         this.log.info('Successfully logged in to Comfort Cloud.');
         this.noOfFailedLoginAttempts = 0;
-        this.configureOutdoorUnit();
         this.discoverDevices();
       })
       .catch((error) => {
@@ -284,7 +283,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
       for (const device of comfortCloudDevices) {
 
         // Check if for this device in plugin config option to show dummy outdoor unit is enabled.
-        const deviceConfig = this.platformConfig.devices.find((item) => item.name === device.deviceName) 
+        const deviceConfig = this.platformConfig.devices.find((item) => item.name === device.deviceName)
           || this.platformConfig.devices.find((item) => item.name === device.deviceGuid) || {};
         // Configure outdoor unit - add or remove, debend on deviceConfig.exposeOutdoorUnit value.
         this.configureOutdoorUnit(device.deviceName, device.deviceGuid, deviceConfig.exposeOutdoorUnit);
@@ -340,7 +339,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
           if (comfortCloudDevice === undefined) {
             // This cached devices does not exist on the Comfort Cloud account (anymore).
             this.configureOutdoorUnit(device.deviceName, device.deviceGuid, false);
-            
+
             this.log.info(`Removing accessory '${cachedAccessory.displayName}' (${guid}) `
               + 'because it does not exist on the Comfort Cloud account or has been excluded in plugin config.');
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -281,10 +281,10 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
       // Exclude by individual device config
       if (this.platformConfig.devices) {
-        const devConfigExcludeList = this.platformConfig.devices;
-        devConfigExcludeList = devConfigExcludeList.filter(el => (el.disabled === true));
+        let devConfigExcludeList = this.platformConfig.devices;
+        devConfigExcludeList = devConfigExcludeList.filter(el => (el.excludeDevice === true));
         devConfigExcludeList = devConfigExcludeList.map(item => item.name);
-        
+
         // exclude by serial number
         comfortCloudDevices = comfortCloudDevices.filter(el => !devConfigExcludeList.includes(el.deviceGuid));
         //exclude by name

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -338,7 +338,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
           if (comfortCloudDevice === undefined) {
             // This cached devices does not exist on the Comfort Cloud account (anymore).
-            this.configureOutdoorUnit(device.deviceName, device.deviceGuid, false);
+            this.configureOutdoorUnit(cachedAccessory.context.device.deviceName, cachedAccessory.context.device.deviceGuid, false);
 
             this.log.info(`Removing accessory '${cachedAccessory.displayName}' (${guid}) `
               + 'because it does not exist on the Comfort Cloud account or has been excluded in plugin config.');


### PR DESCRIPTION
# Version 3.0.0

WARNING! Read carefully before updating!

- This version introduces a huge novelty, from now on you can choose settings for each device separately. Fields such as: Oscilate Switch, Auto Mode, Force Nanoe, Force Swing, Force Inside Cleaning, Force Eco Navi, Minimum Heating Temp. and Expose Outdoor Unit, from now on are individual for each device.
- Fixed the temperature sensor mechanism of the outdoor unit, from now on it has the same name as the main unit with the note "(outdoor)".
- Fixed the login and error mechanism.
- Redesigned layout of plugin config.
- Minor bugs and dependency updates.

WARNING!
The update may involve the fact that some fields in the plugin settings will have to be filled in again and/or some devices in HomeKit could need to be reconfigured.


## Most important things to test in beta:
- in plugin settings add new device, fill name or serial, and test field excludeDevice (is this remove device from HomeKit?) and field exposeOutdoorUnit (is dummy sensor added and showing temp from outdoor unit?)