### PR TITLE
Use Play Store rather than App Store to fetch latest version

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -114,7 +114,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
         }
       });
       if (!foundVersion) {
-        this.log.error('Could not find latest app version.');
+        throw new Error('Could not find latest app version.');
       }
     };
 
@@ -141,8 +141,14 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
     try {
       await getPlayStoreVersion();
     } catch (error) {
-      this.log.error('Could not fetch latest app version from Store.');
+      this.log.error('Could not fetch latest app version from Play Store. Trying App Store.');
       this.log.debug(JSON.stringify(error, null, 2));
+      try {
+        await getAppStoreVersion();
+      } catch (error) {
+        this.log.error('Could not fetch latest app version from App Store.');
+        this.log.debug(JSON.stringify(error, null, 2));
+      }
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -83,24 +83,38 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
   async getAppVersion() {
     this.log.info(`Plugin App version: ${APP_VERSION}.`);
-    this.log.debug('Attempting to fetch latest Comfort Cloud version from the App Store.');
+    this.log.debug('Attempting to fetch latest Comfort Cloud version from the Play Store.');
     try {
+      let foundVersion = false;
       const response = await axios.request({
         method: 'get',
-        url: 'https://apps.apple.com/app/panasonic-comfort-cloud/id1348640525',
+        url: 'https://play.google.com/store/apps/details?id=com.panasonic.ACCsmart',
       });
       const $ = cheerio.load(response.data);
-      const paragraphs = $('p.whats-new__latest__version');
-      paragraphs.each((idx, p) => {
-        // One or more digit(s), followed by ., followed by one or more digit(s),
-        // followed by ., followed by one or more digit(s)
-        const matches = $(p).text().match(/\d+(.)\d+(.)\d+/);
-        if (Array.isArray(matches)) {
-          this.log.info(`The latest App Store version: ${matches[0]}.`);
-        } else {
-          this.log.error('Could not find latest App Store version.');
+      // version data is not displayed in clear text on the page, but instead included in some cryptic JS function call.
+      // The function call is `AF_initDataCallback()`, but there are many of them. The function call additionally contains
+      // (several) references to the app store page for the app in other languages, so it also contains the package name
+      // which allows us to further narrow it down
+      $('script').each((idx, script) => {
+        const textContent = $(script).text();
+        const isCallback = textContent.includes('AF_initDataCallback(') && textContent.includes('com.panasonic.ACCsmart');
+        if (isCallback) {
+          // finally, the version number is of the format major.minor.patch, surrounded by quotation marks. If we find that
+          // we pray it's actually the number and not something else...
+          const matches = textContent.match(/['"](\d+\.\d+\.\d+)['"]/);
+          if (Array.isArray(matches) && (1 in matches)) {
+            this.log.info(`The latest Play Store version is ${matches[1]}.`);
+            if (matches[1] !== APP_VERSION) {
+              this.log.error(`Plugin App version is ${APP_VERSION}. You may experience issues.`);
+            }
+            foundVersion = true;
+            return;
+          }
         }
       });
+      if (!foundVersion) {
+        this.log.error('Could not find latest app version.');
+      }
     } catch (error) {
       this.log.error('Could not fetch latest app version from App Store.');
       this.log.debug(JSON.stringify(error, null, 2));

--- a/test/test-discover.ts
+++ b/test/test-discover.ts
@@ -9,5 +9,6 @@ const platform = new PanasonicPlatform(
   config,
   new HomebridgeAPI,
 );
+platform.getAppVersion();
 
 platform.loginAndDiscoverDevices();


### PR DESCRIPTION
I propose to use the Google Play Store rather than the Apple Play store to detect the latest version.

This is because this is now hard coded to use the latest Play Store version and Client ID, so a mis-match with the Apple App Store is irrelevant.