### PR TITLE
Refresh the token a bit sooner than 24 hours

### DIFF
--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -308,7 +308,7 @@ export default class ComfortCloudApi {
     // STEP 8 - set timer to refresh token --------------------------------------------
 
     // Refresh token every 24 hours
-    setTimeout(this.refreshToken.bind(this), 86400000);
+    setTimeout(this.refreshToken.bind(this), 86300000);
 
   }
 


### PR DESCRIPTION
This is because the token expires after 24 hours, so if we only refresh it after 24 hours we might encounter race conditions where we make API requests with an expired token just split seconds before refreshing it.

I don't think this has a particularly high chance, but it seems like a prudent precaution and I cannot foresee any negative consequences from it.