### PR TITLE
Update to Node 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-panasonic-ac-platform",
-  "version": "6.8.1",
+  "version": "6.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-panasonic-ac-platform",
-      "version": "6.8.1",
+      "version": "6.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.2",
@@ -27,7 +27,7 @@
       },
       "engines": {
         "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-        "node": "^20.19.0 || ^22.15.0"
+        "node": "^20.19.0 || ^22.15.0 || ^24.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -142,7 +142,7 @@
         "ciao-bcs": "lib/bonjour-conformance-testing.js"
       },
       "engines": {
-        "node": "^18 || ^20 || ^22"
+        "node": "^18 || ^20 || ^22 || ^24.0.0"
       }
     },
     "node_modules/@homebridge/dbus-native": {
@@ -2236,7 +2236,7 @@
         "homebridge": "bin/homebridge"
       },
       "engines": {
-        "node": "^18.15.0 || ^20.7.0 || ^22"
+        "node": "^18.15.0 || ^20.7.0 || ^22 || ^24.0.0"
       }
     },
     "node_modules/htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "6.8.1",
+  "version": "6.8.2",
   "maintainers": [
     "jandersonhill"
   ],
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/homebridge-panasonic-ac-platform/homebridge-panasonic-ac-platform#readme",
   "engines": {
     "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-    "node": "^20.19.0 || ^22.15.0"
+    "node": "^20.19.0 || ^22.15.0 || ^24.0.0"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
this is to correct use off node 24 engines.


Maybe for the Node_Modules it is better to use;
"node": ">=24.0.0"
or
"node": "*"

on this moment Homebridge is on 24.12.0 and my old setup on 22.21.1.

Kind Regards