### PR TITLE
feat: zone control for ducted units with a zone controller (CZ-CAPZ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ When enabled it will create a dummy temperature sensor which will display the te
 
 * `exposeFanSpeed` (boolean): When enabled it will create a switch to control Fan Speed. Value 0 will turn device off, value from 1 to 20 = speed 1, value from 21 to 40 = speed 2, value from 41 to 60 = speed 3, value from 61 to 80 = speed 4, value from 81 to 99 = speed 5 and value 100 = speed auto. Note: changing value will turn off Quiet / Powerful mode.
 
+* `exposeZones` (boolean): For ducted units with a zone controller (e.g. CZ-CAPZ). When enabled, each configured zone is exposed as a Fan accessory: on/off plus a slider for the damper opening (0-100%, in steps of 10). Zone names are read automatically from Comfort Cloud. Has no effect on units without a zone controller.
+
+* `exposeZoneTemperature` (boolean): For ducted units with a zone controller. When enabled, each zone that has a temperature sensor is exposed as a temperature sensor (zones without a sensor are skipped). Independent of `exposeZones`. Has no effect on units without a zone controller.
+
 * `swingDefaultUD` (string):
 Desired position of the Up-Down flaps when swing is switched off.
 
@@ -164,7 +168,7 @@ HomeKit has a limited number of switches, which is much less than the number of 
 <details>
 <summary><b>Additional sensors and switches</b></summary>
     
-- Enable additional sensor for outdoor temp. and/or switches for: Nanoe, Inside Cleaning, Eco Navi, Cool Mode, Heat Mode, Dry Mode, Fan mode, Quiet Mode, Powerful Mode, Swing Up Down, Swing Left Right, Fan Speed, etc.
+- Enable additional sensor for outdoor temp. and/or switches for: Nanoe, Inside Cleaning, Eco Navi, Cool Mode, Heat Mode, Dry Mode, Fan mode, Quiet Mode, Powerful Mode, Swing Up Down, Swing Left Right, Fan Speed, Zones (ducted units with a zone controller), etc.
 - Sensor / Switch will work only if device support this function.
 - Some values can be changed only when device is turned on (E.G.: Quiet Mode, Powerful mode, Swing Up Down, Swing Left Right).
 - These sensors / switches will be available in HomeKit, directly in your main device or in device / settings (wheel icon) / accessories. 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ When enabled it will create a dummy temperature sensor which will display the te
 
 * `exposeZoneTemperature` (boolean): For ducted units with a zone controller. When enabled, each zone that has a temperature sensor is exposed as a temperature sensor (zones without a sensor are skipped). Independent of `exposeZones`. Has no effect on units without a zone controller.
 
+* `zonesHideDevicePrefix` (boolean): By default each zone accessory is named `<device name> <zone name>` (e.g. `Ducted Family Room`). Enable this to name zones by zone name only (e.g. `Family Room`, and `Family Room temp` for the sensor). Handy with a single unit; leave off if zone names could clash across multiple units.
+
 * `swingDefaultUD` (string):
 Desired position of the Up-Down flaps when swing is switched off.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -300,6 +300,18 @@
 							"description": "When enabled it will create a switch to control Fan Speed. Value 0 will turn device off, value from 1 to 20 = speed 1, value from 21 to 40 = speed 2, value from 41 to 60 = speed 3, value from 61 to 80 = speed 4, value from 81 to 99 = speed 5 and value 100 = speed auto. Note: changing value will turn off Quiet / Powerful mode.",
 							"type": "boolean",
 							"default": false
+						},
+						"exposeZones": {
+							"title": "Expose Zones",
+							"description": "For ducted units with a zone controller (e.g. CZ-CAPZ). When enabled, each configured zone is exposed as a Fan accessory: on/off plus a slider that sets the damper opening (0-100%, in steps of 10). Zones are read automatically from Comfort Cloud, including their names. Has no effect on units without a zone controller.",
+							"type": "boolean",
+							"default": false
+						},
+						"exposeZoneTemperature": {
+							"title": "Expose Zone Temperatures",
+							"description": "For ducted units with a zone controller. When enabled, each zone that has a temperature sensor is exposed as a temperature sensor (zones without a sensor are skipped). Independent of Expose Zones. Has no effect on units without a zone controller.",
+							"type": "boolean",
+							"default": false
 						}
 					}
 				}
@@ -428,6 +440,17 @@
 										"devices[].exposeInsideCleaning",
 										"devices[].exposeEcoNavi",
 										"devices[].exposeEcoFunction"
+									]
+								},
+								{
+									"type": "section",
+									"title": "Zones (ducted)",
+									"flex": "1 1 100%",
+									"expandable": true,
+									"expanded": false,
+									"items": [
+										"devices[].exposeZones",
+										"devices[].exposeZoneTemperature"
 									]
 								}
 							]

--- a/config.schema.json
+++ b/config.schema.json
@@ -312,6 +312,12 @@
 							"description": "For ducted units with a zone controller. When enabled, each zone that has a temperature sensor is exposed as a temperature sensor (zones without a sensor are skipped). Independent of Expose Zones. Has no effect on units without a zone controller.",
 							"type": "boolean",
 							"default": false
+						},
+						"zonesHideDevicePrefix": {
+							"title": "Zone names without device prefix",
+							"description": "By default each zone accessory is named '<device name> <zone name>' (e.g. 'Ducted Family Room'). Enable this to name zones by zone name only (e.g. 'Family Room', and 'Family Room temp' for the sensor). Handy with a single unit; leave off if zone names could clash across multiple units.",
+							"type": "boolean",
+							"default": false
 						}
 					}
 				}
@@ -450,7 +456,8 @@
 									"expanded": false,
 									"items": [
 										"devices[].exposeZones",
-										"devices[].exposeZoneTemperature"
+										"devices[].exposeZoneTemperature",
+										"devices[].zonesHideDevicePrefix"
 									]
 								}
 							]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/homebridge-panasonic-ac-platform/homebridge-panasonic-ac-platform#readme",
   "engines": {
     "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-    "node": "^20.19.0 || ^22.15.0"
+    "node": "^20.19.0 || ^22.15.0 || ^24.0.0"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/src/indoor-unit.ts
+++ b/src/indoor-unit.ts
@@ -1073,6 +1073,11 @@ export default class IndoorUnitAccessory {
         }
 
         // Keep the HomeKit name in sync with the configured Comfort Cloud name.
+        // ConfiguredName isn't a standard Fan characteristic, so declare it as
+        // optional before setting it — otherwise HAP logs a warning on add.
+        if (!service.testCharacteristic(this.platform.Characteristic.ConfiguredName)) {
+          service.addOptionalCharacteristic(this.platform.Characteristic.ConfiguredName);
+        }
         service.setCharacteristic(this.platform.Characteristic.ConfiguredName, displayName);
 
         // Bind onSet handlers only once per zone service.
@@ -1106,6 +1111,11 @@ export default class IndoorUnitAccessory {
         if (!service) {
           service = this.accessory.addService(this.platform.Service.TemperatureSensor, displayName, subtype);
           this.platform.log.debug(`${this.accessory.displayName}: add zone temp '${zoneName}' (id ${zone.zoneId})`);
+        }
+        // As above: ConfiguredName isn't standard on TemperatureSensor, so
+        // declare it optional before setting to avoid a HAP warning.
+        if (!service.testCharacteristic(this.platform.Characteristic.ConfiguredName)) {
+          service.addOptionalCharacteristic(this.platform.Characteristic.ConfiguredName);
         }
         service.setCharacteristic(this.platform.Characteristic.ConfiguredName, displayName);
         service.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, zone.zoneTemperature as number);

--- a/src/indoor-unit.ts
+++ b/src/indoor-unit.ts
@@ -1055,12 +1055,16 @@ export default class IndoorUnitAccessory {
         continue;
       }
       const zoneName = zone.zoneName?.trim() || `Zone ${zone.zoneId}`;
+      // By default zone accessories are named "<device> <zone>" (e.g. the other
+      // exposed switches follow the same pattern). With zonesHideDevicePrefix
+      // the device-name prefix is dropped, giving just "<zone>".
+      const namePrefix = this.deviceConfig?.zonesHideDevicePrefix ? '' : `${this.accessory.displayName} `;
 
       // Fan service: on/off (zoneOnOff) + damper opening (zoneLevel).
       if (exposeZones) {
         const subtype = `zone-${zone.zoneId}`;
         wantedSubtypes.add(subtype);
-        const displayName = `${this.accessory.displayName} ${zoneName}`;
+        const displayName = `${namePrefix}${zoneName}`;
 
         let service = this.accessory.getServiceById(this.platform.Service.Fan, subtype);
         if (!service) {
@@ -1096,7 +1100,7 @@ export default class IndoorUnitAccessory {
       if (exposeZoneTemp && hasTemp) {
         const subtype = `zone-temp-${zone.zoneId}`;
         wantedSubtypes.add(subtype);
-        const displayName = `${this.accessory.displayName} ${zoneName} temp`;
+        const displayName = `${namePrefix}${zoneName} temp`;
 
         let service = this.accessory.getServiceById(this.platform.Service.TemperatureSensor, subtype);
         if (!service) {

--- a/src/indoor-unit.ts
+++ b/src/indoor-unit.ts
@@ -1,6 +1,6 @@
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import PanasonicPlatform from './platform';
-import { ComfortCloudDeviceUpdatePayload, PanasonicAccessoryContext } from './types';
+import { ComfortCloudDeviceUpdatePayload, ComfortCloudZone, PanasonicAccessoryContext } from './types';
 
 /**
  * An instance of this class is created for each accessory the platform registers.
@@ -34,6 +34,9 @@ export default class IndoorUnitAccessory {
   exposeSwingUpDown;
   exposeSwingLeftRight;
   exposeFanSpeed;
+  // Tracks which zone Fan services (by zoneId) have already had their
+  // onSet handlers bound, so refreshes don't re-bind them.
+  zoneServices: Set<number> = new Set();
 
   constructor(
     private readonly platform: PanasonicPlatform,
@@ -558,6 +561,9 @@ export default class IndoorUnitAccessory {
         this.exposeFanSpeed.updateCharacteristic(this.platform.Characteristic.RotationSpeed, rotationSpeed);
       }
 
+      // Zones (ducted units with a zone controller)
+      this.updateZones();
+
       // Cooling Threshold Temperature (optional)
       // Heating Threshold Temperature (optional)
       this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
@@ -1009,6 +1015,148 @@ export default class IndoorUnitAccessory {
 
   // ===============================================================================================================================================
 
+  /**
+   * Creates, updates and removes per-zone services based on the `zoneParameters`
+   * array in the latest device status (present only on units with a zone controller).
+   *
+   * - 'exposeZones': each zone becomes a Fan — On maps to the zone's on/off state
+   *   (zoneOnOff) and RotationSpeed to the damper opening (zoneLevel, 0-100% step 10).
+   * - 'exposeZoneTemperature': each zone that has a temperature sensor becomes a
+   *   TemperatureSensor (zones report -255 when no sensor is fitted, and are skipped).
+   *
+   * Both options are independent and per-device; when neither is enabled (or the
+   * device reports no zones) all previously-created zone services are removed.
+   */
+  updateZones() {
+    const zones = this.deviceStatus?.zoneParameters as ComfortCloudZone[] | undefined;
+    const hasZones = Array.isArray(zones) && zones.length > 0;
+    const exposeZones = !!this.deviceConfig?.exposeZones && hasZones;
+    const exposeZoneTemp = !!this.deviceConfig?.exposeZoneTemperature && hasZones;
+
+    const isZoneService = (service: Service) => service.subtype?.startsWith('zone-') ?? false;
+
+    if (!exposeZones && !exposeZoneTemp) {
+      // Remove any zone services previously created for this accessory.
+      this.accessory.services
+        .filter(isZoneService)
+        .forEach(service => {
+          this.accessory.removeService(service);
+          this.platform.log.debug(`${this.accessory.displayName}: remove zone service '${service.subtype}'`);
+        });
+      this.zoneServices.clear();
+      return;
+    }
+
+    // Subtypes we want to keep this pass; anything else gets pruned below.
+    const wantedSubtypes = new Set<string>();
+
+    for (const zone of zones as ComfortCloudZone[]) {
+      if (zone.zoneId === undefined || zone.zoneId === null) {
+        continue;
+      }
+      const zoneName = zone.zoneName?.trim() || `Zone ${zone.zoneId}`;
+
+      // Fan service: on/off (zoneOnOff) + damper opening (zoneLevel).
+      if (exposeZones) {
+        const subtype = `zone-${zone.zoneId}`;
+        wantedSubtypes.add(subtype);
+        const displayName = `${this.accessory.displayName} ${zoneName}`;
+
+        let service = this.accessory.getServiceById(this.platform.Service.Fan, subtype);
+        if (!service) {
+          service = this.accessory.addService(this.platform.Service.Fan, displayName, subtype);
+          this.platform.log.debug(`${this.accessory.displayName}: add zone '${zoneName}' (id ${zone.zoneId})`);
+        }
+
+        // Keep the HomeKit name in sync with the configured Comfort Cloud name.
+        service.setCharacteristic(this.platform.Characteristic.ConfiguredName, displayName);
+
+        // Bind onSet handlers only once per zone service.
+        if (!this.zoneServices.has(zone.zoneId)) {
+          service.getCharacteristic(this.platform.Characteristic.On)
+            .onSet(value => this.setZoneOnOff(zone.zoneId, value));
+          service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+            .setProps({ minValue: 0, maxValue: 100, minStep: 10 })
+            .onSet(value => this.setZoneDamper(zone.zoneId, value));
+          this.zoneServices.add(zone.zoneId);
+        }
+
+        // Update current state from the device.
+        if (zone.zoneOnOff !== undefined) {
+          service.updateCharacteristic(this.platform.Characteristic.On, zone.zoneOnOff === 1);
+        }
+        if (zone.zoneLevel !== undefined) {
+          service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, zone.zoneLevel);
+        }
+      }
+
+      // Temperature sensor: only for zones that actually have a sensor
+      // (Comfort Cloud reports -255 when a zone has no temperature sensor).
+      const hasTemp = typeof zone.zoneTemperature === 'number' && zone.zoneTemperature > -255;
+      if (exposeZoneTemp && hasTemp) {
+        const subtype = `zone-temp-${zone.zoneId}`;
+        wantedSubtypes.add(subtype);
+        const displayName = `${this.accessory.displayName} ${zoneName} temp`;
+
+        let service = this.accessory.getServiceById(this.platform.Service.TemperatureSensor, subtype);
+        if (!service) {
+          service = this.accessory.addService(this.platform.Service.TemperatureSensor, displayName, subtype);
+          this.platform.log.debug(`${this.accessory.displayName}: add zone temp '${zoneName}' (id ${zone.zoneId})`);
+        }
+        service.setCharacteristic(this.platform.Characteristic.ConfiguredName, displayName);
+        service.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, zone.zoneTemperature as number);
+      }
+    }
+
+    // Prune any zone service that's no longer wanted: a toggle switched off,
+    // a zone that disappeared, or a temp sensor whose zone lost its reading.
+    this.accessory.services
+      .filter(isZoneService)
+      .forEach(service => {
+        if (!wantedSubtypes.has(service.subtype as string)) {
+          const fanMatch = /^zone-(\d+)$/.exec(service.subtype as string);
+          if (fanMatch) {
+            this.zoneServices.delete(Number(fanMatch[1]));
+          }
+          this.accessory.removeService(service);
+          this.platform.log.debug(`${this.accessory.displayName}: remove zone service '${service.subtype}'`);
+        }
+      });
+  }
+
+  // set Zone on/off
+  async setZoneOnOff(zoneId: number, value: CharacteristicValue) {
+    this.platform.log.debug(`${this.accessory.displayName}: setZoneOnOff(${zoneId})`);
+    const parameters: ComfortCloudDeviceUpdatePayload = {
+      zoneParameters: [{ zoneId, zoneOnOff: value ? 1 : 0 }],
+    };
+    this.platform.log[(this.platform.platformConfig.logsLevel >= 1) ? 'info' : 'debug'](
+      `${this.accessory.displayName}: zone ${zoneId} ${value ? 'On' : 'Off'}`);
+    this.sendDeviceUpdate(this.accessory.context.device.deviceGuid, parameters);
+  }
+
+  // set Zone damper (0-100%, in steps of 10)
+  async setZoneDamper(zoneId: number, value: CharacteristicValue) {
+    this.platform.log.debug(`${this.accessory.displayName}: setZoneDamper(${zoneId}), value: ${value}`);
+    const level = Math.round((value as number) / 10) * 10;
+    const parameters: ComfortCloudDeviceUpdatePayload = {};
+
+    if (level <= 0) {
+      // HomeKit drops rotation speed to 0 when a fan is switched off,
+      // so treat a fully-closed damper as turning the zone off.
+      parameters.zoneParameters = [{ zoneId, zoneOnOff: 0 }];
+      this.platform.log[(this.platform.platformConfig.logsLevel >= 1) ? 'info' : 'debug'](
+        `${this.accessory.displayName}: zone ${zoneId} Off`);
+    } else {
+      parameters.zoneParameters = [{ zoneId, zoneOnOff: 1, zoneLevel: level }];
+      this.platform.log[(this.platform.platformConfig.logsLevel >= 1) ? 'info' : 'debug'](
+        `${this.accessory.displayName}: zone ${zoneId} damper ${level}%`);
+    }
+    this.sendDeviceUpdate(this.accessory.context.device.deviceGuid, parameters);
+  }
+
+  // ===============================================================================================================================================
+
   async setThresholdTemperature(value: CharacteristicValue) {
     /**
      * This function is used for Cooling AND Heating Threshold Temperature,
@@ -1045,6 +1193,25 @@ export default class IndoorUnitAccessory {
       // HomeKit sends commands when a move starts, not when it ends, so there can be several commands during one move.
       // Users often send several commands at once, e.g. in automation.
       // Collect together all parameters sent in a specified time, so as not to send each parameters separately.
+
+      // zoneParameters is an array, so a plain Object.assign would let a later
+      // update overwrite an earlier one (losing changes to other zones). Merge
+      // by zoneId instead so changes to several zones accumulate.
+      if (payload.zoneParameters) {
+        const merged: ComfortCloudZone[] = this.sendDeviceUpdatePayload.zoneParameters || [];
+        for (const zone of payload.zoneParameters) {
+          const existing = merged.find((z: ComfortCloudZone) => z.zoneId === zone.zoneId);
+          if (existing) {
+            Object.assign(existing, zone);
+          } else {
+            merged.push(zone);
+          }
+        }
+        this.sendDeviceUpdatePayload.zoneParameters = merged;
+        payload = { ...payload };
+        delete payload.zoneParameters;
+      }
+
       this.sendDeviceUpdatePayload = Object.assign(this.sendDeviceUpdatePayload, payload);
 
       clearTimeout(this.timerSendDeviceUpdate);

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,26 @@ export interface ComfortCloudDeviceStatus {
   ecoFunctionData: number;
   insideCleaning: number;
   lastSettingMode: number;
+  // Present only on devices with a zone controller (e.g. ducted units with a
+  // CZ-CAPZ zone box). Absent on standard single/multi-split units.
+  zoneParameters?: ComfortCloudZone[];
+}
+
+/**
+ * A single zone reported by / sent to a zone controller.
+ * Only `zoneId` is guaranteed to be present in every context.
+ */
+export interface ComfortCloudZone {
+  zoneId: number;
+  // Configured zone name, e.g. "Living", "Bedrooms".
+  zoneName?: string;
+  // Zone on/off state. Off = 0, On = 1.
+  zoneOnOff?: number;
+  // Damper opening in percent (0-100, in steps of 10).
+  zoneLevel?: number;
+  // Per-zone temperature. -255 means the zone has no temperature sensor.
+  zoneTemperature?: number;
+  zoneSpill?: number;
 }
 
 // Set device status
@@ -115,4 +135,7 @@ export interface ComfortCloudDeviceUpdatePayload {
   ecoFunctionData?: number;
   insideCleaning?: number;
   lastSettingMode?: number;
+  // Send only the zones being changed, each with its zoneId plus the field(s)
+  // to update, e.g. [{ zoneId: 1, zoneOnOff: 1 }].
+  zoneParameters?: ComfortCloudZone[];
 }


### PR DESCRIPTION
## What

Adds optional HomeKit support for the individual zones on ducted units fitted with a Panasonic zone controller (e.g. CZ-CAPZ1M/S).

Comfort Cloud already reports these zones in the device status as a `zoneParameters` array — the plugin just wasn't reading it. Two independent, per-device options are added:

- **Expose Zones** (`exposeZones`) — each zone becomes a **Fan**:
  - **On** → zone on/off (`zoneOnOff`)
  - **Rotation speed** → damper opening (`zoneLevel`, 0–100% in steps of 10)
- **Expose Zone Temperatures** (`exposeZoneTemperature`) — each zone that has a sensor becomes a **temperature sensor** (zones report `-255` when no sensor is fitted and are skipped).

Zone names come from Comfort Cloud (`zoneName`). Zone accessories are created / updated / removed dynamically from whatever the device reports, and rapid changes to multiple zones are merged by `zoneId` in the existing outgoing-update debounce so none are lost. Units without a zone controller report no `zoneParameters`, so nothing changes for them.

## Why

Requested in #52 (closed at the time because no maintainer had the hardware to implement and test it).

## Changes

- `src/types.ts` – add `ComfortCloudZone`; optional `zoneParameters` on device status + update payload
- `src/indoor-unit.ts` – build / refresh / remove per-zone Fan and TemperatureSensor services; on/off + damper set handlers; merge `zoneParameters` by `zoneId`
- `config.schema.json` – new per-device `exposeZones` and `exposeZoneTemperature` toggles (under a "Zones (ducted)" section)
- `README.md` – document both options

## Testing

Tested on real hardware: indoor **S-160PE3R** / outdoor **U-160PZH2R5** ducted system with a **CZ-CAPZ1M** 8-zone controller (6 zones configured):

- All 6 zone names read correctly; on/off reflects and controls the AC; the damper slider maps to `zoneLevel`.
- Zone temperatures are exposed for the 4 zones that have sensors; the 2 zones reporting `-255` are correctly skipped.
- Verified live in the Home app / Homebridge UI against the unit. `npm run lint` and `npm run build` both pass.

## Notes

Backwards compatible and opt-in — both options default to `false`, so existing setups are unaffected until enabled.
